### PR TITLE
Fix mei version

### DIFF
--- a/legacy/MEI2013 (2.1)/Music/Complete examples/Czerny_op603_6.mei
+++ b/legacy/MEI2013 (2.1)/Music/Complete examples/Czerny_op603_6.mei
@@ -2,8 +2,8 @@
 <?xml-model href="http://music-encoding.googlecode.com/svn/tags/MEI2013_v2.1.1/schemata/mei-CMN.rng" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <?xml-model href="http://music-encoding.googlecode.com/svn/tags/MEI2013_v2.1.1/schemata/mei-CMN.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <mei xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.music-encoding.org/ns/mei"
-  meiversion.num="2.1.0" meiversion="2013">
-  <meiHead meiversion.num="2.1.0">
+  meiversion.num="2.1.1" meiversion="2013">
+  <meiHead meiversion.num="2.1.1">
     <fileDesc>
       <titleStmt>
         <title>Praeludium et Fuga (d-Moll) op. 603/6</title>
@@ -192,7 +192,7 @@
       </change>
     </revisionDesc>
   </meiHead>
-  <music meiversion.num="2.1.0">
+  <music meiversion.num="2.1.1">
     <body>
       <mdiv>
         <score>

--- a/legacy/MEI2013 (2.1)/Music/Complete examples/Schubert_Lindenbaum.mei
+++ b/legacy/MEI2013 (2.1)/Music/Complete examples/Schubert_Lindenbaum.mei
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?xml-model href="http://music-encoding.googlecode.com/svn/tags/MEI2013_v2.1.0/schemata/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="http://music-encoding.googlecode.com/svn/tags/MEI2013_v2.1.0/schemata/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://music-encoding.googlecode.com/svn/tags/MEI2013_v2.1.1/schemata/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://music-encoding.googlecode.com/svn/tags/MEI2013_v2.1.1/schemata/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" xmlns:xlink="http://www.w3.org/1999/xlink"
   meiversion="2013">
   <meiHead>

--- a/legacy/MEI2013 (2.1)/Music/Lyrics/multiple_verses.mei
+++ b/legacy/MEI2013 (2.1)/Music/Lyrics/multiple_verses.mei
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?xml-model href="http://music-encoding.googlecode.com/svn/tags/MEI2013_v2.1.0/schemata/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="http://music-encoding.googlecode.com/svn/tags/MEI2013_v2.1.0/schemata/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://music-encoding.googlecode.com/svn/tags/MEI2013_v2.1.1/schemata/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://music-encoding.googlecode.com/svn/tags/MEI2013_v2.1.1/schemata/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" xmlns:xlink="http://www.w3.org/1999/xlink"
   meiversion="2013">
   <meiHead>


### PR DESCRIPTION
some files in the legacy mei2013 2.1 folder had wrong schema refereces or meiversion.num attribute values. This PR fixes that.
