### PR TITLE
add missing @dur

### DIFF
--- a/legacy/MEI2013 (2.1)/Header/Authority data/Example_Authority_data.mei
+++ b/legacy/MEI2013 (2.1)/Header/Authority data/Example_Authority_data.mei
@@ -194,7 +194,7 @@
 														<syl wordpos="i">Ber</syl>
 													</verse>
 												</note>
-												<note pname="e" oct="5" stem.dir="down">
+												<note pname="e" oct="5" dur="8" stem.dir="down">
 													<verse>
 														<syl wordpos="t">gen</syl>
 													</verse>


### PR DESCRIPTION
one note in the Example_Authority_data.mei was missing the dur attribute
an no dur.default is being defined in the file.
With this commit an assumed value for dur is added to the note.
Unfortunately there was no access to the "original", so the value is
based upon the time signature an the dur values of the other notes of
the corresponding layer.
