### PR TITLE
Sample Altenburg_concerto_C_major.mei: Grace notes aren't under beam

### DIFF
--- a/MEI 3.0/Music/Complete examples/Altenburg_concerto_C_major.mei
+++ b/MEI 3.0/Music/Complete examples/Altenburg_concerto_C_major.mei
@@ -406,8 +406,8 @@
                            <beam>
                               <note xml:id="d6409e1169" pname="f" oct="5" dur="8"/>
                               <note xml:id="d6409e1183" pname="e" oct="5" dur="8"/>
-                              <note xml:id="d6409e1197" grace="unacc" pname="f" oct="5" dur="16"/>
                            </beam>
+                           <note xml:id="d6409e1197" grace="unacc" pname="f" oct="5" dur="16"/>
                            <beam>
                               <note xml:id="d6409e1212" pname="e" oct="5" dur="8"/>
                               <note xml:id="d6409e1228" pname="d" oct="5" dur="16"/>
@@ -511,8 +511,8 @@
                            <beam>
                               <note xml:id="d6409e1682" pname="f" oct="5" dur="8"/>
                               <note xml:id="d6409e1696" pname="e" oct="5" dur="8"/>
-                              <note xml:id="d6409e1710" grace="unacc" pname="e" oct="5" dur="8"/>
                            </beam>
+                           <note xml:id="d6409e1710" grace="unacc" pname="e" oct="5" dur="8"/>
                            <note xml:id="d6409e1725" pname="d" oct="5" dur="4"/>
                            <rest xml:id="d6409e1739" dur="8"/>
                            <note xml:id="d6409e1747" pname="g" oct="5" dur="8"/>
@@ -994,8 +994,8 @@
                            <beam>
                               <note xml:id="d6409e4502" pname="f" oct="5" dur="8"/>
                               <note xml:id="d6409e4516" pname="e" oct="5" dur="8"/>
-                              <note xml:id="d6409e4530" grace="unacc" pname="f" oct="5" dur="8"/>
                            </beam>
+                           <note xml:id="d6409e4530" grace="unacc" pname="f" oct="5" dur="8"/>
                            <beam>
                               <note xml:id="d6409e4545" pname="e" oct="5" dur="8"/>
                               <note xml:id="d6409e4561" pname="d" oct="5" dur="16"/>
@@ -1082,8 +1082,8 @@
                            <beam>
                               <note xml:id="d6409e5019" pname="f" oct="5" dur="8"/>
                               <note xml:id="d6409e5033" pname="e" oct="5" dur="8"/>
-                              <note xml:id="d6409e5047" grace="unacc" pname="e" oct="5" dur="8"/>
                            </beam>
+                           <note xml:id="d6409e5047" grace="unacc" pname="e" oct="5" dur="8"/>
                            <note xml:id="d6409e5063" pname="d" oct="5" dur="4"/>
                            <rest xml:id="d6409e5078" dur="8"/>
                            <note xml:id="d6409e5086" pname="g" oct="5" dur="8"/>
@@ -1655,8 +1655,8 @@
                            <beam>
                               <note xml:id="d6409e8267" pname="f" oct="5" dur="8"/>
                               <note xml:id="d6409e8281" pname="e" oct="5" dur="8"/>
-                              <note xml:id="d6409e8295" grace="unacc" pname="e" oct="5" dur="8"/>
                            </beam>
+                           <note xml:id="d6409e8295" grace="unacc" pname="e" oct="5" dur="8"/>
                            <note xml:id="d6409e8310" pname="d" oct="5" dur="4"/>
                            <rest xml:id="d6409e8324" dur="8"/>
                            <note xml:id="d6409e8332" pname="g" oct="5" dur="8"/>
@@ -2441,8 +2441,8 @@
                            <beam>
                               <note xml:id="d6409e12358" pname="f" oct="5" dur="8"/>
                               <note xml:id="d6409e12372" pname="e" oct="5" dur="8"/>
-                              <note xml:id="d6409e12386" grace="unacc" pname="e" oct="5" dur="8"/>
                            </beam>
+                           <note xml:id="d6409e12386" grace="unacc" pname="e" oct="5" dur="8"/>
                            <note xml:id="d6409e12401" pname="d" oct="5" dur="4"/>
                            <rest xml:id="d6409e12415" dur="4"/>
                         </layer>
@@ -4371,8 +4371,8 @@
                            <beam>
                               <note xml:id="d6409e22632" pname="f" oct="5" dur="8"/>
                               <note xml:id="d6409e22646" pname="e" oct="5" dur="8"/>
-                              <note xml:id="d6409e22660" grace="unacc" pname="e" oct="5" dur="8"/>
                            </beam>
+                           <note xml:id="d6409e22660" grace="unacc" pname="e" oct="5" dur="8"/>
                            <note xml:id="d6409e22675" pname="d" oct="5" dur="4"/>
                            <rest xml:id="d6409e22689" dur="8"/>
                            <note xml:id="d6409e22697" pname="g" oct="5" dur="8"/>
@@ -4422,8 +4422,8 @@
                            <beam>
                               <note xml:id="d6409e22998" pname="f" oct="5" dur="8"/>
                               <note xml:id="d6409e23012" pname="e" oct="5" dur="8"/>
-                              <note xml:id="d6409e23026" grace="unacc" pname="e" oct="5" dur="8"/>
                            </beam>
+                           <note xml:id="d6409e23026" grace="unacc" pname="e" oct="5" dur="8"/>
                            <note xml:id="d6409e23041" pname="d" oct="5" dur="4"/>
                            <rest xml:id="d6409e23055" dur="8"/>
                            <note xml:id="d6409e23063" pname="g" oct="5" dur="8"/>


### PR DESCRIPTION
Judging from the PDF, this should be corrected. The changes validate against the 3.0.0 schema.
