### PR TITLE
Correct incorrectly nested beams

### DIFF
--- a/MEI 3.0/Music/Complete examples/Debussy_Golliwogg'sCakewalk.mei
+++ b/MEI 3.0/Music/Complete examples/Debussy_Golliwogg'sCakewalk.mei
@@ -157,10 +157,10 @@
                                  <note pname="b" oct="4" dur="16" stem.dir="up" artic="acc"/>
                                  <note pname="a" oct="4" dur="8" stem.dir="up" artic="stacc"/>
                                  <note pname="b" oct="4" dur="16" stem.dir="up"/>
-                                 <beam>
-                                    <note pname="f" oct="4" dur="8" stem.dir="up" artic="stacc"/>
-                                    <note pname="b" oct="4" dur="8" stem.dir="up" artic="stacc"/>
-                                 </beam>
+                              </beam>
+                              <beam>
+                                 <note pname="f" oct="4" dur="8" stem.dir="up" artic="stacc"/>
+                                 <note pname="b" oct="4" dur="8" stem.dir="up" artic="stacc"/>
                               </beam>
                            </layer>
                         </staff>


### PR DESCRIPTION
An additional question somewhat related to this pull request:  The PDF file for Golliwogg's Cakewalk actually starts with Doctor Gradus ad Parnassum, which was a little irritating for me because the encoding did not at all match the music I saw on page 1.  Shouldn't we extract the 5 relevant pages from the 31 page PDF?