### PR TITLE
Add missing figured bass markup

### DIFF
--- a/MEI 3.0/Musical features/snippets/Figured_Bass.mei
+++ b/MEI 3.0/Musical features/snippets/Figured_Bass.mei
@@ -1143,9 +1143,21 @@
                            <f>6</f>
                         </fb>
                      </harm>
-                     <harm staff="3" place="below" tstamp="1.5">7</harm>
-                     <harm staff="3" place="below" tstamp="2">6 </harm>
-                     <harm staff="3" place="below" tstamp="3">7 </harm>
+                     <harm staff="3" place="below" tstamp="1.5">
+                       <fb>
+                         <f>7</f>
+                       </fb>
+                     </harm>
+                     <harm staff="3" place="below" tstamp="2">
+                       <fb>
+                         <f>6</f>
+                       </fb>
+                     </harm>
+                     <harm staff="3" place="below" tstamp="3">
+                       <fb>
+                         <f>7</f>
+                       </fb>
+                     </harm>
                   </measure>
                   <ending n="1">
                      <measure n="48" xml:id="m48" right="dbldotted">


### PR DESCRIPTION
Only place in the sample set where there was no markup around figured bass numerals.