### PR TITLE
add `@role`

### DIFF
--- a/MEI_3.0/Header/Authority_data/Example_Authority_data.mei
+++ b/MEI_3.0/Header/Authority_data/Example_Authority_data.mei
@@ -15,7 +15,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND"
+               <corpName codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND" role="pbl"
                   >Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>

--- a/MEI_3.0/Header/Authority_data/Example_Authority_data_II.mei
+++ b/MEI_3.0/Header/Authority_data/Example_Authority_data_II.mei
@@ -9,21 +9,12 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar &lt;<geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
-                            authority="TGN">Detmold</geogName>&gt;</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar &lt;<geogName codedval="7004442" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Detmold</geogName>&gt;</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
-               <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
-                            authority="TGN">Detmold</geogName>
-               </addrLine>
-               <addrLine>
-                  <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
-                            authority="TGN">Germany</geogName>
-               </addrLine>
+               <addrLine>32756 <geogName codedval="7004442" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Detmold</geogName></addrLine>
+               <addrLine> <geogName codedval="7000084" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Germany</geogName></addrLine>
             </address>
             <date>2011</date>
             <availability>
@@ -38,38 +29,18 @@
             <title>MEI Sample Collection</title>
             <respStmt>
                <corpName role="publisher">MEI Project</corpName>
-               <corpName role="funder"
-                         codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
-                         authority="GND">German Research Foundation
-						<address>
+               <corpName role="funder" codedval="2007744-0" authURI="http://d-nb.info/gnd/"  authority="GND">German Research Foundation
+                  <address>
                      <addrLine>Kennedyallee 40</addrLine>
-                     <addrLine>53175 <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
-                                  authority="TGN">Bonn</geogName>
-                     </addrLine>
-                     <addrLine>
-                        <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
-                                  authority="TGN">Germany</geogName>
-                     </addrLine>
+                     <addrLine>53175 <geogName codedval="7005090" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Bonn</geogName></addrLine>
+                     <addrLine><geogName codedval="7000084" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Germany</geogName></addrLine>
                   </address>
                </corpName>
-               <corpName role="funder"
-                         codedval="18183-3"
-                         authURI="http://d-nb.info/gnd"
-                         authority="GND">National Endowment for the Humanities
-						<address>
+               <corpName role="funder" codedval="18183-3" authURI="http://d-nb.info/gnd/" authority="GND">National Endowment for the Humanities
+                  <address>
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
-                     <addrLine>
-                        <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
-                                  authority="TGN">Washington, DC</geogName> 20004</addrLine>
-                     <addrLine>
-                        <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
-                                  authority="TGN">United States</geogName>
-                     </addrLine>
+                     <addrLine> <geogName codedval="7013962" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Washington, DC</geogName> 20004</addrLine>
+                     <addrLine> <geogName codedval="7012149" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">United States</geogName></addrLine>
                   </address>
                </corpName>
             </respStmt>
@@ -80,15 +51,8 @@
                <titleStmt>
                   <title>Dichterliebe</title>
                   <respStmt>
-                     <persName role="composer"
-                               codedval="118611666"
-                               authURI="http://d-nb.info/gnd"
-                               authority="Deusche Nationalbibliothek">Robert Schumann</persName>
-                     <persName role="lyricist"
-                               codedval="118548018"
-                               authURI="http://d-nb.info/gnd"
-                               authority="GND">Heinrich
-								Heine</persName>
+                     <persName role="composer" codedval="118611666" authURI="http://d-nb.info/gnd/" authority="Deusche Nationalbibliothek">Robert Schumann</persName>
+                     <persName role="lyricist" codedval="118548018" authURI="http://d-nb.info/gnd/" authority="GND">Heinrich Heine</persName>
                      <persName role="dedicatee">Wilhelmine Schröder-Devrient</persName>
                   </respStmt>
                </titleStmt>
@@ -129,10 +93,8 @@
             <titleStmt>
                <title type="uniform">Dichterliebe &lt;Im wunderschönen Monat Mai&gt;</title>
                <respStmt>
-                  <persName role="composer"
-                            codedval="118611666"
-                            authURI="http://d-nb.info/gnd"
-                            authority="GND">Robert Schumann</persName>
+                  <persName role="composer" codedval="118611666" authURI="http://d-nb.info/gnd/"
+                     authority="GND">Robert Schumann</persName>
                </respStmt>
             </titleStmt>
             <key pname="a" mode="major">A major</key>

--- a/MEI_3.0/Music/Complete_examples/Aguado_Walzer_G-major.mei
+++ b/MEI_3.0/Music/Complete_examples/Aguado_Walzer_G-major.mei
@@ -6,18 +6,18 @@
             <title>Walzer G-Dur</title>
             <title type="subordinate">an electronic transcription</title>
             <respStmt>
-               <persName role="creator" codedval="133912027" authURI="http://d-nb.info/gnd" authority="GND">Dionisio Aguado y García</persName>
+               <persName role="creator" codedval="133912027" authURI="http://d-nb.info/gnd/" authority="GND">Dionisio Aguado y García</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
             </respStmt>
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
-               <addrLine>32756 <geogName codedval="7004442" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Detmold</geogName>
+               <addrLine>32756 <geogName codedval="7004442" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Germany</geogName>
@@ -78,7 +78,7 @@
                      <addrLine>Postfach 68</addrLine>
                   </address>
                   <availability>
-                     <useRestrict>(C) Jürgen Knuth</useRestrict>
+                     <useRestrict>(C) Jürgen W. Knuth</useRestrict>
                   </availability>
                </pubStmt>
             </source>

--- a/MEI_3.0/Musical-features/snippets/meterChange.mei
+++ b/MEI_3.0/Musical-features/snippets/meterChange.mei
@@ -14,7 +14,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName>Musikwissenschaftliches Seminar Detmold/Paderborn</corpName>
+               <corpName role="publisher">Musikwissenschaftliches Seminar Detmold/Paderborn</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>


### PR DESCRIPTION
Validation issued a schematron warning statin: "If at least one resp element isn't present, all name-like elements should have a @role attribute."

This commit adds `@role`on `corpName`in the `puStmt`