### PR TITLE
Fix authority file refs

### DIFF
--- a/MEI_3.0/Header/Authority_data/Example_Authority_data.mei
+++ b/MEI_3.0/Header/Authority_data/Example_Authority_data.mei
@@ -21,12 +21,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                     authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
+                     authURI="http://vocab.getty.edu/page/tgn/" authority="TGN"
                      >Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                     authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
+                     authURI="http://vocab.getty.edu/page/tgn/" authority="TGN"
                      >Germany</geogName>
                </addrLine>
             </address>
@@ -48,12 +48,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                           authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
+                           authURI="http://vocab.getty.edu/page/tgn/" authority="TGN"
                            >Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                           authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
+                           authURI="http://vocab.getty.edu/page/tgn/" authority="TGN"
                            >Germany</geogName>
                      </addrLine>
                   </address>
@@ -63,11 +63,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                           authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
+                           authURI="http://vocab.getty.edu/page/tgn/" authority="TGN"
                            >Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                           authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
+                           authURI="http://vocab.getty.edu/page/tgn/" authority="TGN"
                            >United States</geogName>
                      </addrLine>
                   </address>
@@ -96,7 +96,7 @@
                   </publisher>
                   <pubPlace>
                      <geogName codedval="7012329"
-                        authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
+                        authURI="http://vocab.getty.edu/page/tgn/" authority="TGN"
                         >Leipzig</geogName>
                   </pubPlace>
                   <date>1853</date>

--- a/MEI_3.0/Music/Complete_examples/Aguado_Walzer_G-major.mei
+++ b/MEI_3.0/Music/Complete_examples/Aguado_Walzer_G-major.mei
@@ -20,7 +20,7 @@
                <addrLine>32756 <geogName codedval="7004442" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
-                  <geogName codedval="7000084" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Germany</geogName>
+                  <geogName codedval="7000084" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Germany</geogName>
                </addrLine>
             </address>
             <date>2011</date>
@@ -39,19 +39,19 @@
                <corpName role="funder" codedval="2007744-0" authURI="http://d-nb.info/gnd/" authority="GND">German Research Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
-                        <geogName codedval="7005090" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Bonn</geogName>
+                        <geogName codedval="7005090" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
-                        <geogName codedval="7000084" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Germany</geogName>
+                        <geogName codedval="7000084" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
                </corpName>
                <corpName role="funder" codedval="18183-3" authURI="http://d-nb.info/gnd/" authority="GND">National Endowment for the Humanities<address>
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
-                        <geogName codedval="7013962" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Washington, DC</geogName> 20004</addrLine>
+                        <geogName codedval="7013962" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
-                        <geogName codedval="7012149" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">United States</geogName>
+                        <geogName codedval="7012149" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">United States</geogName>
                      </addrLine>
                   </address>
                </corpName>

--- a/MEI_3.0/Music/Complete_examples/Aguado_Walzer_G-major.mei
+++ b/MEI_3.0/Music/Complete_examples/Aguado_Walzer_G-major.mei
@@ -6,14 +6,14 @@
             <title>Walzer G-Dur</title>
             <title type="subordinate">an electronic transcription</title>
             <respStmt>
-               <persName role="creator" codedval="133912027" authURI="http://d-nb.info/gnd" authority="GND">Dionisio Aguado y García</persName>
+               <persName role="creator" codedval="133912027" authURI="http://d-nb.info/gnd/" authority="GND">Dionisio Aguado y García</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
             </respStmt>
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -36,7 +36,7 @@
             <title>MEI Sample Collection</title>
             <respStmt>
                <corpName role="publisher">MEI Project</corpName>
-               <corpName role="funder" codedval="2007744-0" authURI="http://d-nb.info/gnd" authority="GND">German Research Foundation<address>
+               <corpName role="funder" codedval="2007744-0" authURI="http://d-nb.info/gnd/" authority="GND">German Research Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Bonn</geogName>
@@ -46,7 +46,7 @@
                      </addrLine>
                   </address>
                </corpName>
-               <corpName role="funder" codedval="18183-3" authURI="http://d-nb.info/gnd" authority="GND">National Endowment for the Humanities<address>
+               <corpName role="funder" codedval="18183-3" authURI="http://d-nb.info/gnd/" authority="GND">National Endowment for the Humanities<address>
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Washington, DC</geogName> 20004</addrLine>
@@ -66,7 +66,7 @@
                <titleStmt>
                   <title>Walzer G-Dur</title>
                   <respStmt>
-                     <persName role="composer" codedval="133912027" authURI="http://d-nb.info/gnd" authority="GND">Dionisio Aguado y García</persName>
+                     <persName role="composer" codedval="133912027" authURI="http://d-nb.info/gnd/" authority="GND">Dionisio Aguado y García</persName>
                   </respStmt>
                </titleStmt>
                <pubStmt>
@@ -102,7 +102,7 @@
             <titleStmt>
                <title>Walzer G-Dur</title>
                <respStmt>
-                  <persName role="composer" codedval="133912027" authURI="http://d-nb.info/gnd" authority="GND">Dionisio Aguado y García</persName>
+                  <persName role="composer" codedval="133912027" authURI="http://d-nb.info/gnd/" authority="GND">Dionisio Aguado y García</persName>
                </respStmt>
             </titleStmt>
             <key pname="g" mode="major">G major</key>

--- a/MEI_3.0/Music/Complete_examples/Ahle_Jesu_meines_Herzens_Freud.mei
+++ b/MEI_3.0/Music/Complete_examples/Ahle_Jesu_meines_Herzens_Freud.mei
@@ -15,7 +15,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -38,7 +38,7 @@
             <title>MEI Sample Collection</title>
             <respStmt>
                <corpName role="publisher">MEI Project</corpName>
-               <corpName role="funder" codedval="2007744-0" authURI="http://d-nb.info/gnd" authority="GND">German Research
+               <corpName role="funder" codedval="2007744-0" authURI="http://d-nb.info/gnd/" authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>

--- a/MEI_3.0/Music/Complete_examples/Ahle_Jesu_meines_Herzens_Freud.mei
+++ b/MEI_3.0/Music/Complete_examples/Ahle_Jesu_meines_Herzens_Freud.mei
@@ -19,10 +19,10 @@
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
-               <addrLine>32756 <geogName codedval="7004442" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Detmold</geogName>
+               <addrLine>32756 <geogName codedval="7004442" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
-                  <geogName codedval="7000084" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Germany</geogName>
+                  <geogName codedval="7000084" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Germany</geogName>
                </addrLine>
             </address>
             <date>2011</date>
@@ -42,10 +42,10 @@
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
-                        <geogName codedval="7005090" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Bonn</geogName>
+                        <geogName codedval="7005090" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
-                        <geogName codedval="7000084" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Germany</geogName>
+                        <geogName codedval="7000084" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
                </corpName>
@@ -53,9 +53,9 @@
                   Humanities<address>
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
-                        <geogName codedval="7013962" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Washington, DC</geogName> 20004</addrLine>
+                        <geogName codedval="7013962" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
-                        <geogName codedval="7012149" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">United States</geogName>
+                        <geogName codedval="7012149" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">United States</geogName>
                      </addrLine>
                   </address>
                </corpName>

--- a/MEI_3.0/Music/Complete_examples/Altenburg_Ein_feste_Burg.mei
+++ b/MEI_3.0/Music/Complete_examples/Altenburg_Ein_feste_Burg.mei
@@ -15,7 +15,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -44,7 +44,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
@@ -88,7 +88,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="11864839X"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Michael Altenburg</persName>
                   </respStmt>
                </titleStmt>
@@ -124,7 +124,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="11864839X"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Michael Altenburg</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Altenburg_Ein_feste_Burg.mei
+++ b/MEI_3.0/Music/Complete_examples/Altenburg_Ein_feste_Burg.mei
@@ -20,12 +20,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -49,12 +49,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -66,11 +66,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Altenburg_Macht_auf_die_Tor.mei
+++ b/MEI_3.0/Music/Complete_examples/Altenburg_Macht_auf_die_Tor.mei
@@ -17,10 +17,10 @@
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
-               <addrLine>32756 <geogName codedval="7004442" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Detmold</geogName>
+               <addrLine>32756 <geogName codedval="7004442" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
-                  <geogName codedval="7000084" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Germany</geogName>
+                  <geogName codedval="7000084" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Germany</geogName>
                </addrLine>
             </address>
             <date>2011</date>
@@ -40,20 +40,20 @@
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
-                        <geogName codedval="7005090" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Bonn</geogName>
+                        <geogName codedval="7005090" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
-                        <geogName codedval="7000084" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Germany</geogName>
+                        <geogName codedval="7000084" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
                </corpName>
                <corpName role="funder" codedval="18183-3" authURI="http://d-nb.info/gnd/18183-3" authority="Deutsche Nationalbibliothek">National Endowment for the Humanities<address>
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
-                        <geogName codedval="7013962" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Washington, DC</geogName>
+                        <geogName codedval="7013962" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Washington, DC</geogName>
                         20004</addrLine>
                      <addrLine>
-                        <geogName codedval="7012149" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">United States</geogName>
+                        <geogName codedval="7012149" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">United States</geogName>
                      </addrLine>
                   </address>
                </corpName>

--- a/MEI_3.0/Music/Complete_examples/Altenburg_Macht_auf_die_Tor.mei
+++ b/MEI_3.0/Music/Complete_examples/Altenburg_Macht_auf_die_Tor.mei
@@ -13,7 +13,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -36,7 +36,7 @@
             <title>MEI Sample Collection</title>
             <respStmt>
                <corpName role="publisher">MEI Project</corpName>
-               <corpName role="funder" codedval="2007744-0" authURI="http://d-nb.info/gnd" authority="GND">German Research
+               <corpName role="funder" codedval="2007744-0" authURI="http://d-nb.info/gnd/" authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
@@ -68,7 +68,7 @@
                <titleStmt>
                   <title>Macht auf die Tor der Grechtigkeit</title>
                   <respStmt>
-                     <persName role="composer" codedval="11864839X" authURI="http://d-nb.info/gnd" authority="GND">Michael Altenburg</persName>
+                     <persName role="composer" codedval="11864839X" authURI="http://d-nb.info/gnd/" authority="GND">Michael Altenburg</persName>
                   </respStmt>
                </titleStmt>
             </source>
@@ -105,7 +105,7 @@
             <titleStmt>
                <title>Macht auf die Tor der Gerechtigkeit</title>
                <respStmt>
-                  <persName role="composer" codedval="11864839X" authURI="http://d-nb.info/gnd" authority="GND">Michael Altenburg</persName>
+                  <persName role="composer" codedval="11864839X" authURI="http://d-nb.info/gnd/" authority="GND">Michael Altenburg</persName>
                </respStmt>
             </titleStmt>
             <key pname="a" mode="minor">A minor</key>

--- a/MEI_3.0/Music/Complete_examples/Altenburg_concerto_C_major.mei
+++ b/MEI_3.0/Music/Complete_examples/Altenburg_concerto_C_major.mei
@@ -18,10 +18,10 @@
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
-               <addrLine>32756 <geogName codedval="7004442" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Detmold</geogName>
+               <addrLine>32756 <geogName codedval="7004442" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
-                  <geogName codedval="7000084" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Germany</geogName>
+                  <geogName codedval="7000084" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Germany</geogName>
                </addrLine>
             </address>
             <date>2011</date>
@@ -40,19 +40,19 @@
                <corpName role="funder" codedval="2007744-0" authURI="http://d-nb.info/gnd/" authority="GND">German Research Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
-                        <geogName codedval="7005090" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Bonn</geogName>
+                        <geogName codedval="7005090" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
-                        <geogName codedval="7000084" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Germany</geogName>
+                        <geogName codedval="7000084" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
                </corpName>
                <corpName role="funder" codedval="18183-3" authURI="http://d-nb.info/gnd/18183-3" authority="Deutsche Nationalbibliothek">National Endowment for the Humanities<address>
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
-                        <geogName codedval="7013962" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Washington, DC</geogName> 20004</addrLine>
+                        <geogName codedval="7013962" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
-                        <geogName codedval="7012149" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">United States</geogName>
+                        <geogName codedval="7012149" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">United States</geogName>
                      </addrLine>
                   </address>
                </corpName>

--- a/MEI_3.0/Music/Complete_examples/Altenburg_concerto_C_major.mei
+++ b/MEI_3.0/Music/Complete_examples/Altenburg_concerto_C_major.mei
@@ -7,14 +7,14 @@
                heroisch-musikalischen Trompeter - und Pauker - Kunst"</title>
             <title type="subordinate">an electronic transcription</title>
             <respStmt>
-               <persName role="creator" codedval="108138054" authURI="http://d-nb.info/gnd" authority="GND">Johann Ernst Altenburg</persName>
+               <persName role="creator" codedval="108138054" authURI="http://d-nb.info/gnd/" authority="GND">Johann Ernst Altenburg</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
             </respStmt>
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -37,7 +37,7 @@
             <title>MEI Sample Collection</title>
             <respStmt>
                <corpName role="publisher">MEI Project</corpName>
-               <corpName role="funder" codedval="2007744-0" authURI="http://d-nb.info/gnd" authority="GND">German Research Foundation<address>
+               <corpName role="funder" codedval="2007744-0" authURI="http://d-nb.info/gnd/" authority="GND">German Research Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Bonn</geogName>
@@ -69,7 +69,7 @@
                		heroisch-musikalischen Trompeter - und Pauker - Kunst"</title>
                   <title type="uniform">Konzerte &lt;1795&gt;</title>
                   <respStmt>
-                     <persName role="composer" codedval="108138054" authURI="http://d-nb.info/gnd" authority="GND">Johann Ernst Altenburg</persName>
+                     <persName role="composer" codedval="108138054" authURI="http://d-nb.info/gnd/" authority="GND">Johann Ernst Altenburg</persName>
                   </respStmt>
                </titleStmt>
                <pubStmt>
@@ -108,7 +108,7 @@
                <title>Concerto à 7 Trompeten und Pauken aus "Versuch einer Anleitung zur
             		heroisch-musikalischen Trompeter - und Pauker - Kunst"</title>
                <respStmt>
-                  <persName role="composer" codedval="108138054" authURI="http://d-nb.info/gnd" authority="GND">Johann Ernst Altenburg</persName>
+                  <persName role="composer" codedval="108138054" authURI="http://d-nb.info/gnd/" authority="GND">Johann Ernst Altenburg</persName>
                </respStmt>
             </titleStmt>
             <key pname="c" mode="major">C major</key>

--- a/MEI_3.0/Music/Complete_examples/Bach-J-C_Fughette_Gmaj.mei
+++ b/MEI_3.0/Music/Complete_examples/Bach-J-C_Fughette_Gmaj.mei
@@ -13,7 +13,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="120327112"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Johann Christoph Bach</persName>
                <persName role="arranger">Michel Rondeau</persName>
                <persName role="encoder">Maja Hartwig</persName>
@@ -22,7 +22,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -51,7 +51,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
 						Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -98,7 +98,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="120327112"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Johann Christoph
 								Bach</persName>
                      <persName role="arranger">Michel Rondeau</persName>
@@ -128,7 +128,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="120327112"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Johann Christoph Bach</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Bach-J-C_Fughette_Gmaj.mei
+++ b/MEI_3.0/Music/Complete_examples/Bach-J-C_Fughette_Gmaj.mei
@@ -27,12 +27,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -57,12 +57,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -75,11 +75,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Bach-J-C_Fughette_No2.mei
+++ b/MEI_3.0/Music/Complete_examples/Bach-J-C_Fughette_No2.mei
@@ -11,7 +11,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="120327112"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="Deutsche Nationalbibliothek">Johann Christoph Bach</persName>
                <persName role="arranger">Michel Rondeau</persName>
                <persName role="encoder">Maja Hartwig</persName>
@@ -20,7 +20,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -49,7 +49,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -96,7 +96,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="120327112"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="Deutsche Nationalbibliothek">Johann Christoph Bach</persName>
                      <persName role="arranger">Michel Rondeau</persName>
                   </respStmt>
@@ -125,7 +125,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="120327112"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Johann Christoph Bach</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Bach-J-C_Fughette_No2.mei
+++ b/MEI_3.0/Music/Complete_examples/Bach-J-C_Fughette_No2.mei
@@ -25,12 +25,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -55,12 +55,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -73,11 +73,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Bach_BrandenburgConcert_No.4_I.mei
+++ b/MEI_3.0/Music/Complete_examples/Bach_BrandenburgConcert_No.4_I.mei
@@ -11,7 +11,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="1180553X"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Johann Sebastian Bach</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -19,7 +19,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -48,7 +48,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
@@ -94,7 +94,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="1180553X"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Johann Sebastian Bach</persName>
                      <persName role="editor">Michel Rondeau</persName>
                   </respStmt>
@@ -138,7 +138,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="1180553X"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Johann Sebastian Bach</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Bach_BrandenburgConcert_No.4_I.mei
+++ b/MEI_3.0/Music/Complete_examples/Bach_BrandenburgConcert_No.4_I.mei
@@ -24,12 +24,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -53,12 +53,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -70,11 +70,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Bach_BrandenburgConcert_No.4_II.mei
+++ b/MEI_3.0/Music/Complete_examples/Bach_BrandenburgConcert_No.4_II.mei
@@ -11,7 +11,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="1180553X"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Johann Sebastian Bach</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -19,7 +19,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -48,7 +48,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
 						Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -97,7 +97,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="1180553X"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Johann Sebastian
 								Bach</persName>
                      <persName role="editor">Michel Rondeau</persName>
@@ -149,7 +149,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="1180553X"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Johann Sebastian Bach</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Bach_BrandenburgConcert_No.4_II.mei
+++ b/MEI_3.0/Music/Complete_examples/Bach_BrandenburgConcert_No.4_II.mei
@@ -24,12 +24,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -54,12 +54,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -72,11 +72,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Bach_Ein_festeBurg.mei
+++ b/MEI_3.0/Music/Complete_examples/Bach_Ein_festeBurg.mei
@@ -23,7 +23,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -52,7 +52,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
 						Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>

--- a/MEI_3.0/Music/Complete_examples/Bach_Ein_festeBurg.mei
+++ b/MEI_3.0/Music/Complete_examples/Bach_Ein_festeBurg.mei
@@ -28,12 +28,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -58,12 +58,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -76,11 +76,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Bach_Herzliebster_Jesu.mei
+++ b/MEI_3.0/Music/Complete_examples/Bach_Herzliebster_Jesu.mei
@@ -16,7 +16,7 @@
          <pubStmt>
             <respStmt>
                <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar &lt;<geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>&gt;</corpName>
             </respStmt>
             <address>

--- a/MEI_3.0/Music/Complete_examples/Bach_Herzliebster_Jesu.mei
+++ b/MEI_3.0/Music/Complete_examples/Bach_Herzliebster_Jesu.mei
@@ -8,14 +8,14 @@
             <respStmt>
                <persName role="creator"
                          authority="GND"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          codedval="11850553X">Johann Sebastian Bach</persName>
                <persName role="encoder">Perry Roland</persName>
             </respStmt>
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar &lt;<geogName codedval="7004442"
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar &lt;<geogName codedval="7004442"
                             authURI="www.getty.edu/research/tools/vocabularies/tgn"
                             authority="TGN">Detmold</geogName>&gt;</corpName>
             </respStmt>
@@ -74,7 +74,7 @@
                   <respStmt>
                      <persName role="composer"
                                authority="GND"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                codedval="11850553X">Johann Sebastian Bach</persName>
                      <persName role="librettist">Picander, pseud. Christian Friedrich Henrici</persName>
                   </respStmt>
@@ -106,7 +106,7 @@
                <respStmt>
                   <persName role="composer"
                             authority="GND"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             codedval="11850553X">Johann Sebastian Bach</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Bach_Hilf_Herr_Jesu.mei
+++ b/MEI_3.0/Music/Complete_examples/Bach_Hilf_Herr_Jesu.mei
@@ -25,12 +25,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -54,12 +54,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -71,11 +71,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Bach_Hilf_Herr_Jesu.mei
+++ b/MEI_3.0/Music/Complete_examples/Bach_Hilf_Herr_Jesu.mei
@@ -12,7 +12,7 @@
                <persName cert="low"
                          role="creator"
                          codedval="11850553X"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Johann Sebastian Bach</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -20,7 +20,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -49,7 +49,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research  Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
@@ -94,7 +94,7 @@
                   <respStmt>
                      <persName role="composer" cert="low"
                                codedval="11850553X"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Johann Sebastian Bach</persName>
                   </respStmt>
                </titleStmt>
@@ -121,7 +121,7 @@
                <title>Hilf, Herr Jesu, laß gelingen</title>
                <title type="work">BWV 344</title>
                <respStmt>
-                  <persName role="composer" cert="low" authURI="http://d-nb.info/gnd" authority="GND">Johann
+                  <persName role="composer" cert="low" authURI="http://d-nb.info/gnd/" authority="GND">Johann
                      Sebastian Bach</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Bach_Musikalisches_Opfer_Trio.mei
+++ b/MEI_3.0/Music/Complete_examples/Bach_Musikalisches_Opfer_Trio.mei
@@ -21,10 +21,10 @@
                   authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar <address>
                      <addrLine>Gartenstrasse 20</addrLine>
                      <addrLine>32756 <geogName codedval="7004442"
-                           authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
+                           authURI="http://vocab.getty.edu/page/tgn/" authority="TGN"
                            >Detmold</geogName>
                         <geogName codedval="7000084"
-                           authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
+                           authURI="http://vocab.getty.edu/page/tgn/" authority="TGN"
                            >Germany</geogName>
                      </addrLine>
                   </address>
@@ -47,12 +47,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                           authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
+                           authURI="http://vocab.getty.edu/page/tgn/" authority="TGN"
                            >Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                           authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
+                           authURI="http://vocab.getty.edu/page/tgn/" authority="TGN"
                            >Germany</geogName>
                      </addrLine>
                   </address>
@@ -62,11 +62,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                           authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
+                           authURI="http://vocab.getty.edu/page/tgn/" authority="TGN"
                            >Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                           authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
+                           authURI="http://vocab.getty.edu/page/tgn/" authority="TGN"
                            >United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Bach_Musikalisches_Opfer_Trio.mei
+++ b/MEI_3.0/Music/Complete_examples/Bach_Musikalisches_Opfer_Trio.mei
@@ -10,7 +10,7 @@
                Satz)</title>
             <title type="subordinate">an electronic transcription</title>
             <respStmt>
-               <persName role="creator" authURI="http://d-nb.info/gnd" codedval="11850553X"
+               <persName role="creator" authURI="http://d-nb.info/gnd/" codedval="11850553X"
                   authority="GND">Johann Sebastian Bach</persName>
                <persName role="encoder">Maja Hartwig</persName>
             </respStmt>
@@ -18,7 +18,7 @@
          <pubStmt>
             <respStmt>
                <corpName role="publisher" n="2" xml:id="corpName2" codedval="5115204-6"
-                  authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar <address>
+                  authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar <address>
                      <addrLine>Gartenstrasse 20</addrLine>
                      <addrLine>32756 <geogName codedval="7004442"
                            authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
@@ -42,7 +42,7 @@
             <title>MEI Sample Collection</title>
             <respStmt>
                <corpName role="publisher">MEI Project</corpName>
-               <corpName role="funder" codedval="2007744-0" authURI="http://d-nb.info/gnd"
+               <corpName role="funder" codedval="2007744-0" authURI="http://d-nb.info/gnd/"
                   authority="GND">German Research Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
@@ -87,7 +87,7 @@
                   <title type="uniform">Musikalisches Opfer &lt;2. Triosonate c-Moll für Flöte,
                      Violine und Basso continuo&gt;</title>
                   <respStmt>
-                     <persName role="composer" authURI="http://d-nb.info/gnd" codedval="11850553X"
+                     <persName role="composer" authURI="http://d-nb.info/gnd/" codedval="11850553X"
                         authority="GND">Johann Sebastian Bach</persName>
                   </respStmt>
                </titleStmt>
@@ -120,7 +120,7 @@
             <titleStmt>
                <title>Trio</title>
                <respStmt>
-                  <persName role="composer" authURI="http://d-nb.info/gnd" codedval="11850553X"
+                  <persName role="composer" authURI="http://d-nb.info/gnd/" codedval="11850553X"
                      authority="GND">Johann Sebastian Bach</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Bach_Wie_bist_du_Seele.mei
+++ b/MEI_3.0/Music/Complete_examples/Bach_Wie_bist_du_Seele.mei
@@ -11,7 +11,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="11850553X"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Johann Sebastian Bach</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -19,7 +19,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -48,7 +48,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -95,7 +95,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="11850553X"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Johann Sebastian Bach</persName>
                   </respStmt>
                </titleStmt>
@@ -132,7 +132,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="11850553X"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Johann Sebastian Bach</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Bach_Wie_bist_du_Seele.mei
+++ b/MEI_3.0/Music/Complete_examples/Bach_Wie_bist_du_Seele.mei
@@ -24,12 +24,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -54,12 +54,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -72,11 +72,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Beethoven_Song_Op98.mei
+++ b/MEI_3.0/Music/Complete_examples/Beethoven_Song_Op98.mei
@@ -20,12 +20,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -48,12 +48,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -66,11 +66,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Beethoven_Song_Op98.mei
+++ b/MEI_3.0/Music/Complete_examples/Beethoven_Song_Op98.mei
@@ -15,7 +15,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -42,7 +42,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -89,11 +89,11 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="118508288"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Ludwig van Beethoven</persName>
                      <persName role="lyricist"
                                codedval="113667213"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Aloys Isidor Jeitteles</persName>
                      <persName role="dedicatee">Fürst Joseph von Lobkowitz</persName>
                      <persName role="editor">Max Unger</persName>
@@ -135,7 +135,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118508288"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Ludwig van Beethoven</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Berlioz_Symphony_op25.mei
+++ b/MEI_3.0/Music/Complete_examples/Berlioz_Symphony_op25.mei
@@ -20,12 +20,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -50,12 +50,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -68,11 +68,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Berlioz_Symphony_op25.mei
+++ b/MEI_3.0/Music/Complete_examples/Berlioz_Symphony_op25.mei
@@ -15,7 +15,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -44,7 +44,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -91,7 +91,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="118509675"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Hector Berlioz</persName>
                      <persName role="arranger">Michel Rondeau</persName>
                   </respStmt>
@@ -129,7 +129,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118509675"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Hector Berlioz</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Borodin_StringTrio_g.mei
+++ b/MEI_3.0/Music/Complete_examples/Borodin_StringTrio_g.mei
@@ -23,12 +23,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -53,12 +53,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -71,11 +71,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Borodin_StringTrio_g.mei
+++ b/MEI_3.0/Music/Complete_examples/Borodin_StringTrio_g.mei
@@ -10,7 +10,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="118661914"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Alexander P. Borodin</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -18,7 +18,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -47,7 +47,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -94,7 +94,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="118661914"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Alexander P. Borodin</persName>
                   </respStmt>
                </titleStmt>
@@ -121,7 +121,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118661914"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Aleksandr P. Borodin</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Brahms_StringQuartet_Op51_No1.mei
+++ b/MEI_3.0/Music/Complete_examples/Brahms_StringQuartet_Op51_No1.mei
@@ -11,7 +11,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="118514253"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Johannes Brahms</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -19,7 +19,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -48,7 +48,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
 						Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -96,7 +96,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="118514253"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Johannes Brahms</persName>
                      <persName role="dedicatee">Theodor Billroth</persName>
                   </respStmt>
@@ -147,7 +147,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118514253"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Johannes Brahms</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Brahms_StringQuartet_Op51_No1.mei
+++ b/MEI_3.0/Music/Complete_examples/Brahms_StringQuartet_Op51_No1.mei
@@ -24,12 +24,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -54,12 +54,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -72,11 +72,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Brahms_WieMelodienZiehtEsMir.mei
+++ b/MEI_3.0/Music/Complete_examples/Brahms_WieMelodienZiehtEsMir.mei
@@ -18,7 +18,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115198" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar </corpName>
+               <corpName role="publisher" codedval="5115198" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar </corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>

--- a/MEI_3.0/Music/Complete_examples/Chopin_Etude_op.10_no.9.mei
+++ b/MEI_3.0/Music/Complete_examples/Chopin_Etude_op.10_no.9.mei
@@ -15,7 +15,7 @@
       </titleStmt>
       <pubStmt>
         <respStmt>
-          <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd"
+          <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/"
             authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
         </respStmt>
         <address>
@@ -39,7 +39,7 @@
         <title>MEI Sample Collection</title>
         <respStmt>
           <corpName role="publisher">MEI Project</corpName>
-          <corpName role="funder" codedval="2007744-0" authURI="http://d-nb.info/gnd"
+          <corpName role="funder" codedval="2007744-0" authURI="http://d-nb.info/gnd/"
             authority="GND">German Research
             Foundation<address>
           <addrLine>Kennedyallee 40</addrLine>
@@ -77,7 +77,7 @@
             <title type="uniform">Etüden, Kl, op. 10,9</title>
             <respStmt>
               <persName role="composer" codedval="118520539" authority="GND"
-                authURI="http://d-nb.info/gnd">Frédéric Chopin</persName>
+                authURI="http://d-nb.info/gnd/">Frédéric Chopin</persName>
               <persName role="dedicatee">Franz Liszt</persName>
               <persName role="editor">Karl Klindworth</persName>
             </respStmt>
@@ -127,7 +127,7 @@
           <title type="uniform">Etüden, Kl, op. 10,9</title>
           <respStmt>
             <persName role="composer" codedval="118520539" authority="GND"
-              authURI="http://d-nb.info/gnd">Frédéric Chopin</persName>
+              authURI="http://d-nb.info/gnd/">Frédéric Chopin</persName>
             <persName role="dedicatee" authority="GND" authURI=" http://d-nb.info/gnd/"
               codedval="118573527">Franz Liszt</persName>
           </respStmt>

--- a/MEI_3.0/Music/Complete_examples/Chopin_Etude_op.10_no.9.mei
+++ b/MEI_3.0/Music/Complete_examples/Chopin_Etude_op.10_no.9.mei
@@ -20,10 +20,10 @@
         </respStmt>
         <address>
           <addrLine>Gartenstrasse 20</addrLine>
-          <addrLine>32756 <geogName codedval="7004442" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Detmold</geogName>
+          <addrLine>32756 <geogName codedval="7004442" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Detmold</geogName>
         </addrLine>
         <addrLine>
-          <geogName codedval="7000084" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Germany</geogName>
+          <geogName codedval="7000084" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Germany</geogName>
         </addrLine>
       </address>
         <date>2011</date>
@@ -44,10 +44,10 @@
             Foundation<address>
           <addrLine>Kennedyallee 40</addrLine>
           <addrLine>
-            <geogName codedval="7005090" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Bonn</geogName>
+            <geogName codedval="7005090" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Bonn</geogName>
           </addrLine>
           <addrLine>
-            <geogName codedval="7000084" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Germany</geogName>
+            <geogName codedval="7000084" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Germany</geogName>
           </addrLine>
         </address>
           </corpName>
@@ -56,9 +56,9 @@
             Humanities<address>
         <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
         <addrLine>
-          <geogName codedval="7013962" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Washington, DC</geogName> 20004</addrLine>
+          <geogName codedval="7013962" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Washington, DC</geogName> 20004</addrLine>
           <addrLine>
-            <geogName codedval="7012149" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">United States</geogName>
+            <geogName codedval="7012149" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">United States</geogName>
           </addrLine>
         </address>
           </corpName>

--- a/MEI_3.0/Music/Complete_examples/Chopin_Mazurka.mei
+++ b/MEI_3.0/Music/Complete_examples/Chopin_Mazurka.mei
@@ -20,12 +20,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -50,12 +50,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -68,11 +68,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Chopin_Mazurka.mei
+++ b/MEI_3.0/Music/Complete_examples/Chopin_Mazurka.mei
@@ -15,7 +15,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -44,7 +44,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -92,7 +92,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="118520539"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Frédéric Chopin</persName>
                      <persName role="dedicatee">Pauline Plater</persName>
                   </respStmt>
@@ -149,7 +149,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118520539"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Frédéric Chopin</persName>
                   <persName role="dedicatee">Pauline Plater</persName>
                </respStmt>

--- a/MEI_3.0/Music/Complete_examples/Czerny_StringQuartet_d.mei
+++ b/MEI_3.0/Music/Complete_examples/Czerny_StringQuartet_d.mei
@@ -23,12 +23,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -50,12 +50,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -67,11 +67,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Czerny_StringQuartet_d.mei
+++ b/MEI_3.0/Music/Complete_examples/Czerny_StringQuartet_d.mei
@@ -10,7 +10,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="118677667"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Carl Czerny</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -18,7 +18,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -45,7 +45,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
@@ -89,7 +89,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="118677667"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Carl Czerny</persName>
                      <persName role="arranger">Michel Rondeau</persName>
                   </respStmt>
@@ -117,7 +117,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118677667"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Carl Czerny</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Czerny_op603_6.mei
+++ b/MEI_3.0/Music/Complete_examples/Czerny_op603_6.mei
@@ -23,12 +23,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -53,12 +53,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -71,11 +71,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Czerny_op603_6.mei
+++ b/MEI_3.0/Music/Complete_examples/Czerny_op603_6.mei
@@ -10,7 +10,7 @@
             <respStmt>
                <persName role="creator"
                          authority="GND"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          codedval="118677667">Carl Czerny</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -18,7 +18,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -47,7 +47,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
             Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -95,7 +95,7 @@
                   <respStmt>
                      <persName role="composer"
                                authority="GND"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                codedval="118677667">Carl Czerny</persName>
                      <persName role="editor">Patrick Roose</persName>
                   </respStmt>
@@ -128,7 +128,7 @@
                <respStmt>
                   <persName role="composer"
                             authority="GND"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             codedval="118677667">Carl Czerny</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Debussy_Mandoline.mei
+++ b/MEI_3.0/Music/Complete_examples/Debussy_Mandoline.mei
@@ -15,7 +15,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -40,7 +40,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
@@ -85,11 +85,11 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="118524186"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Claude Debussy</persName>
                      <persName role="lyricist"
                                codedval="118804219"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Paul Verlaine</persName>
                   </respStmt>
                </titleStmt>
@@ -135,7 +135,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118524186"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Claude Debussy</persName>
                   <persName role="librettist">Paul Verlaine</persName>
                </respStmt>

--- a/MEI_3.0/Music/Complete_examples/Debussy_Mandoline.mei
+++ b/MEI_3.0/Music/Complete_examples/Debussy_Mandoline.mei
@@ -20,12 +20,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -45,12 +45,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -62,11 +62,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Echigo-Jishi.mei
+++ b/MEI_3.0/Music/Complete_examples/Echigo-Jishi.mei
@@ -16,7 +16,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>

--- a/MEI_3.0/Music/Complete_examples/Gluck_CheFaroSenzaEuridice.mei
+++ b/MEI_3.0/Music/Complete_examples/Gluck_CheFaroSenzaEuridice.mei
@@ -23,12 +23,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -53,12 +53,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -71,11 +71,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Gluck_CheFaroSenzaEuridice.mei
+++ b/MEI_3.0/Music/Complete_examples/Gluck_CheFaroSenzaEuridice.mei
@@ -10,7 +10,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="118539841"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Christoph Willibald Gluck</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -18,7 +18,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -47,7 +47,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
 						Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -93,7 +93,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="118539841"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Christoph Willibald
 								Gluck</persName>
                      <persName role="arranger">Michel Rondeau</persName>
@@ -137,7 +137,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118539841"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Christoph Willibald Gluck</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Grieg_op.43_butterfly.mei
+++ b/MEI_3.0/Music/Complete_examples/Grieg_op.43_butterfly.mei
@@ -22,12 +22,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -52,12 +52,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -70,11 +70,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Grieg_op.43_butterfly.mei
+++ b/MEI_3.0/Music/Complete_examples/Grieg_op.43_butterfly.mei
@@ -17,7 +17,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -46,7 +46,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -94,7 +94,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="11869641"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Edvard Grieg</persName>
                      <persName role="editor">Leopold Godowsky</persName>
                   </respStmt>
@@ -152,7 +152,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="11869641"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Edvard Grieg</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Grieg_op.43_little_bird.mei
+++ b/MEI_3.0/Music/Complete_examples/Grieg_op.43_little_bird.mei
@@ -15,7 +15,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -40,7 +40,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
@@ -86,7 +86,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="11869641"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Edvard Grieg</persName>
                      <corpName role="publisher">C.F. Peters</corpName>
                      <persName role="editor">Hermann Kretzschmar</persName>
@@ -143,7 +143,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="11869641"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Edvard Grieg</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Grieg_op.43_little_bird.mei
+++ b/MEI_3.0/Music/Complete_examples/Grieg_op.43_little_bird.mei
@@ -20,12 +20,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -45,12 +45,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -62,11 +62,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Handel_Arie.mei
+++ b/MEI_3.0/Music/Complete_examples/Handel_Arie.mei
@@ -25,12 +25,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -55,12 +55,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -73,11 +73,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Handel_Arie.mei
+++ b/MEI_3.0/Music/Complete_examples/Handel_Arie.mei
@@ -12,7 +12,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="118544489"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Georg Friedrich Haendel</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -20,7 +20,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -49,7 +49,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -97,7 +97,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="118544489"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Georg Friedrich Haendel</persName>
                      <persName role="arranger">Michel Rondeau</persName>
                      <persName role="librettist">Giacomo Rossi</persName>
@@ -137,7 +137,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118544489"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Georg Friedrich Haendel</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Handel_Messias.mei
+++ b/MEI_3.0/Music/Complete_examples/Handel_Messias.mei
@@ -11,7 +11,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="118544489"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Georg Friedrich Händel</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -19,7 +19,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -48,7 +48,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -96,7 +96,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="118544489"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Georg Friedrich Händel</persName>
                      <persName role="arranger">Michel Rondeau</persName>
                   </respStmt>
@@ -127,7 +127,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118544489"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Georg Friedrich Händel</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Handel_Messias.mei
+++ b/MEI_3.0/Music/Complete_examples/Handel_Messias.mei
@@ -24,12 +24,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -54,12 +54,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -72,11 +72,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Handel_concerto_grosso.mei
+++ b/MEI_3.0/Music/Complete_examples/Handel_concerto_grosso.mei
@@ -11,7 +11,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="118544489"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Georg Friedrich Händel</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -19,7 +19,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -49,7 +49,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
                                     Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -96,7 +96,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="118544489"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Georg Friedrich Händel</persName>
                   </respStmt>
                   <!-- Finale-Datei cesti -->
@@ -119,7 +119,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118544489"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Georg Friedrich Händel</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Handel_concerto_grosso.mei
+++ b/MEI_3.0/Music/Complete_examples/Handel_concerto_grosso.mei
@@ -24,12 +24,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -55,12 +55,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -72,11 +72,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Haydn_StringQuartet_Op1_No1.mei
+++ b/MEI_3.0/Music/Complete_examples/Haydn_StringQuartet_Op1_No1.mei
@@ -25,12 +25,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -55,12 +55,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -73,11 +73,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Haydn_StringQuartet_Op1_No1.mei
+++ b/MEI_3.0/Music/Complete_examples/Haydn_StringQuartet_Op1_No1.mei
@@ -12,7 +12,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="118547356"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Franz Joseph Haydn</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -20,7 +20,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -49,7 +49,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -97,7 +97,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="118547356"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Franz Joseph Haydn</persName>
                   </respStmt>
                </titleStmt>
@@ -142,7 +142,7 @@
                   <resp>composé par</resp>
                   <persName role="composer"
                             codedval="118547356"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Franz Joseph Haydn</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Hopkins_GatherRoundTheChristmasTree.mei
+++ b/MEI_3.0/Music/Complete_examples/Hopkins_GatherRoundTheChristmasTree.mei
@@ -11,7 +11,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="13701158X"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">John Henry Hopkins</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -19,7 +19,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -48,7 +48,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -95,7 +95,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="13701158X"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">John Henry Hopkins</persName>
                      <persName role="arranger">Michel Rondeau</persName>
                   </respStmt>
@@ -131,7 +131,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="13701158X"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">John Henry Hopkins</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Hopkins_GatherRoundTheChristmasTree.mei
+++ b/MEI_3.0/Music/Complete_examples/Hopkins_GatherRoundTheChristmasTree.mei
@@ -24,12 +24,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -54,12 +54,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -72,11 +72,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Ives_TheCage.mei
+++ b/MEI_3.0/Music/Complete_examples/Ives_TheCage.mei
@@ -25,10 +25,10 @@
                         <address>
                      <addrLine>Gartenstrasse 20</addrLine>
                      <addrLine>32756 <geogName codedval="7004442"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Detmold</geogName>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -53,12 +53,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -70,11 +70,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Ives_TheCage.mei
+++ b/MEI_3.0/Music/Complete_examples/Ives_TheCage.mei
@@ -10,7 +10,7 @@
             <respStmt>
                <persName role="creator"
                          authority="GND"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          codedval="118556142">Charles Ives</persName>
                <persName role="encoder">Maja Hartwig</persName>
             </respStmt>
@@ -20,7 +20,7 @@
                <corpName role="publisher" n="2"
                          xml:id="corpName2"
                          codedval="5115204-6"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Musikwissenschaftliches Seminar
                         <address>
                      <addrLine>Gartenstrasse 20</addrLine>
@@ -48,7 +48,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
@@ -93,11 +93,11 @@
                   <respStmt>
                      <persName role="composer"
                                authority="GND"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                codedval="118556142">Charles Ives</persName>
                      <persName role="lyricist"
                                authority="GND"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                codedval="118556142">Charles Ives</persName>
                   </respStmt>
                </titleStmt>
@@ -126,11 +126,11 @@
                <respStmt>
                   <persName role="composer"
                             authority="GND"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             codedval="118556142">Charles Ives</persName>
                   <persName role="lyricist"
                             authority="GND"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             codedval="118556142">Charles Ives</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/JSB_BWV1047_1.mei
+++ b/MEI_3.0/Music/Complete_examples/JSB_BWV1047_1.mei
@@ -12,14 +12,14 @@
                <persName role="creator"
                          codedval="11850553X"
                          authority="GND"
-                         authURI="http://d-nb.info/gnd">Johann Sebastian Bach</persName>
+                         authURI="http://d-nb.info/gnd/">Johann Sebastian Bach</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
             </respStmt>
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -48,7 +48,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -98,7 +98,7 @@
                      <persName role="composer"
                                codedval="11850553X"
                                authority="GND"
-                               authURI="http://d-nb.info/gnd">Johann Sebastian Bach</persName>
+                               authURI="http://d-nb.info/gnd/">Johann Sebastian Bach</persName>
                   </respStmt>
                </titleStmt>
                <pubStmt>
@@ -138,7 +138,7 @@
                   <persName role="composer"
                             codedval="11850553X"
                             authority="GND"
-                            authURI="http://d-nb.info/gnd">Johann Sebastian Bach</persName>
+                            authURI="http://d-nb.info/gnd/">Johann Sebastian Bach</persName>
                </respStmt>
             </titleStmt>
             <key pname="f" mode="major">F major</key>

--- a/MEI_3.0/Music/Complete_examples/JSB_BWV1047_1.mei
+++ b/MEI_3.0/Music/Complete_examples/JSB_BWV1047_1.mei
@@ -24,12 +24,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -54,12 +54,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -72,11 +72,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/JSB_BWV1047_2.mei
+++ b/MEI_3.0/Music/Complete_examples/JSB_BWV1047_2.mei
@@ -12,14 +12,14 @@
                <persName role="creator"
                          codedval="11850553X"
                          authority="GND"
-                         authURI="http://d-nb.info/gnd">Johann Sebastian Bach</persName>
+                         authURI="http://d-nb.info/gnd/">Johann Sebastian Bach</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
             </respStmt>
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -48,7 +48,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
@@ -97,7 +97,7 @@
                      <persName role="composer"
                                codedval="11850553X"
                                authority="GND"
-                               authURI="http://d-nb.info/gnd">Johann Sebastian Bach</persName>
+                               authURI="http://d-nb.info/gnd/">Johann Sebastian Bach</persName>
                   </respStmt>
                </titleStmt>
                <pubStmt>
@@ -136,7 +136,7 @@
                   <persName role="composer"
                             codedval="11850553X"
                             authority="GND"
-                            authURI="http://d-nb.info/gnd">Johann Sebastian Bach</persName>
+                            authURI="http://d-nb.info/gnd/">Johann Sebastian Bach</persName>
                </respStmt>
             </titleStmt>
             <key pname="f" mode="major">F major</key>

--- a/MEI_3.0/Music/Complete_examples/JSB_BWV1047_2.mei
+++ b/MEI_3.0/Music/Complete_examples/JSB_BWV1047_2.mei
@@ -24,12 +24,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -53,12 +53,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -70,12 +70,12 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName>
                         20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/JSB_BWV1047_3.mei
+++ b/MEI_3.0/Music/Complete_examples/JSB_BWV1047_3.mei
@@ -12,14 +12,14 @@
                <persName role="creator"
                          codedval="11850553X"
                          authority="GND"
-                         authURI="http://d-nb.info/gnd">Johann Sebastian Bach</persName>
+                         authURI="http://d-nb.info/gnd/">Johann Sebastian Bach</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
             </respStmt>
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -48,7 +48,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -98,7 +98,7 @@
                      <persName role="composer"
                                codedval="11850553X"
                                authority="GND"
-                               authURI="http://d-nb.info/gnd">Johann Sebastian Bach</persName>
+                               authURI="http://d-nb.info/gnd/">Johann Sebastian Bach</persName>
                   </respStmt>
                </titleStmt>
                <pubStmt>
@@ -138,7 +138,7 @@
                   <persName role="composer"
                             codedval="11850553X"
                             authority="GND"
-                            authURI="http://d-nb.info/gnd">Johann Sebastian Bach</persName>
+                            authURI="http://d-nb.info/gnd/">Johann Sebastian Bach</persName>
                </respStmt>
             </titleStmt>
             <key pname="f" mode="major">F major</key>

--- a/MEI_3.0/Music/Complete_examples/JSB_BWV1047_3.mei
+++ b/MEI_3.0/Music/Complete_examples/JSB_BWV1047_3.mei
@@ -24,12 +24,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -54,12 +54,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -72,11 +72,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Joplin_Elite_Syncopations.mei
+++ b/MEI_3.0/Music/Complete_examples/Joplin_Elite_Syncopations.mei
@@ -23,12 +23,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -53,12 +53,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -71,11 +71,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Joplin_Elite_Syncopations.mei
+++ b/MEI_3.0/Music/Complete_examples/Joplin_Elite_Syncopations.mei
@@ -10,7 +10,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="119174030"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Scott Joplin</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -18,7 +18,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -47,7 +47,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -93,7 +93,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="119174030"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Scott Joplin</persName>
                   </respStmt>
                </titleStmt>
@@ -117,7 +117,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="119174030"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Scott Joplin</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Joplin_Maple_leaf_Rag.mei
+++ b/MEI_3.0/Music/Complete_examples/Joplin_Maple_leaf_Rag.mei
@@ -7,7 +7,7 @@
         <title>Maple Leaf Rag</title>
         <title type="subordinate">an electronic transcription</title>
         <respStmt>
-          <persName role="creator" codedval="119174030" authURI="http://d-nb.info/gnd"
+          <persName role="creator" codedval="119174030" authURI="http://d-nb.info/gnd/"
             authority="GND">Scott Joplin</persName>
           <persName role="encoder">Maja Hartwig</persName>
           <persName role="encoder">Kristina Richts</persName>
@@ -15,7 +15,7 @@
       </titleStmt>
       <pubStmt>
         <respStmt>
-          <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND"
+          <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND"
             >Musikwissenschaftliches Seminar, Detmold</corpName>
         </respStmt>
         <address>
@@ -39,7 +39,7 @@
         <title>MEI Sample Collection</title>
         <respStmt>
           <corpName role="publisher">MEI Project</corpName>
-          <corpName role="funder" codedval="2007744-0" authURI="http://d-nb.info/gnd"
+          <corpName role="funder" codedval="2007744-0" authURI="http://d-nb.info/gnd/"
             authority="GND">German Research
             Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -74,7 +74,7 @@
           <titleStmt>
             <title>Maple Leaf Rag</title>
             <respStmt>
-              <persName role="composer" codedval="119174030" authURI="http://d-nb.info/gnd"
+              <persName role="composer" codedval="119174030" authURI="http://d-nb.info/gnd/"
                 authority="GND">Scott Joplin</persName>
               <persName role="dedicatee">The Maple Leaf Club</persName>
             </respStmt>
@@ -99,7 +99,7 @@
         <titleStmt>
           <title>Maple Leaf Rag</title>
           <respStmt>
-            <persName role="composer" codedval="119174030" authURI="http://d-nb.info/gnd"
+            <persName role="composer" codedval="119174030" authURI="http://d-nb.info/gnd/"
               authority="GND">Scott Joplin</persName>
           </respStmt>
         </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Joplin_Maple_leaf_Rag.mei
+++ b/MEI_3.0/Music/Complete_examples/Joplin_Maple_leaf_Rag.mei
@@ -20,10 +20,10 @@
         </respStmt>
         <address>
                <addrLine>Gartenstrasse 20</addrLine>
-               <addrLine>32756 <geogName codedval="7004442" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Detmold</geogName>
+               <addrLine>32756 <geogName codedval="7004442" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
-                  <geogName codedval="7000084" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Germany</geogName>
+                  <geogName codedval="7000084" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Germany</geogName>
                </addrLine>
             </address>
         <date>2011</date>
@@ -44,10 +44,10 @@
             Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
-                        <geogName codedval="7005090" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Bonn</geogName>
+                        <geogName codedval="7005090" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
-                        <geogName codedval="7000084" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Germany</geogName>
+                        <geogName codedval="7000084" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
           </corpName>
@@ -56,9 +56,9 @@
             Humanities<address>
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
-                        <geogName codedval="7013962" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Washington, DC</geogName> 20004</addrLine>
+                        <geogName codedval="7013962" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
-                        <geogName codedval="7012149" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">United States</geogName>
+                        <geogName codedval="7012149" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">United States</geogName>
                      </addrLine>
                   </address>
           </corpName>

--- a/MEI_3.0/Music/Complete_examples/Kirnberger_FugeInEFlatMajor.mei
+++ b/MEI_3.0/Music/Complete_examples/Kirnberger_FugeInEFlatMajor.mei
@@ -11,7 +11,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="118777238"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Johann Philipp Kirnberger</persName>
                <persName role="arranger">Michel Rondeau</persName>
                <persName xml:id="MH" role="encoder">Maja Hartwig</persName>
@@ -20,7 +20,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -49,7 +49,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -98,7 +98,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="118777238"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Johann Philipp Kirnberger</persName>
                      <persName role="arranger">Michel Rondeau</persName>
                   </respStmt>
@@ -136,7 +136,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118777238"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Johann Philipp Kirnberger</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Kirnberger_FugeInEFlatMajor.mei
+++ b/MEI_3.0/Music/Complete_examples/Kirnberger_FugeInEFlatMajor.mei
@@ -25,12 +25,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -55,12 +55,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -73,11 +73,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Krebs_Trio_Eb_2.mei
+++ b/MEI_3.0/Music/Complete_examples/Krebs_Trio_Eb_2.mei
@@ -11,7 +11,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="123281954"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Johann Ludwig Krebs</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -19,7 +19,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -48,7 +48,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
 						Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -95,7 +95,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="123281954"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Johann Ludwig
 								Krebs</persName>
                      <persName role="editor">Jens Kluge</persName>
@@ -130,7 +130,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="123281954"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Johann Ludwig Krebs</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Krebs_Trio_Eb_2.mei
+++ b/MEI_3.0/Music/Complete_examples/Krebs_Trio_Eb_2.mei
@@ -24,12 +24,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -54,12 +54,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -72,11 +72,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Krebs_Trio_in_c.mei
+++ b/MEI_3.0/Music/Complete_examples/Krebs_Trio_in_c.mei
@@ -25,12 +25,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -55,12 +55,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -73,11 +73,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Krebs_Trio_in_c.mei
+++ b/MEI_3.0/Music/Complete_examples/Krebs_Trio_in_c.mei
@@ -12,7 +12,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="123281954"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Johann Ludwig Krebs</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -20,7 +20,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -49,7 +49,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
             Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -97,7 +97,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="123281954"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Johann Ludwig Krebs</persName>
                      <persName role="editor">Jens Kluge</persName>
                   </respStmt>
@@ -136,7 +136,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="123281954"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Johann Ludwig Krebs</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Liszt_Four_little_pieces.mei
+++ b/MEI_3.0/Music/Complete_examples/Liszt_Four_little_pieces.mei
@@ -9,7 +9,7 @@
             <title type="subordinate">an electronic transcription</title>
             <respStmt>
                <persName role="creator"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="DNB"
                          codedval="118573527">Franz Liszt</persName>
                <persName role="encoder">Perry Roland</persName>
@@ -29,7 +29,7 @@
                <corpName role="publisher" n="2"
                          xml:id="corpName2"
                          codedval="5115204-6"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Musikwissenschaftliches Seminar
                   <address>
                      <addrLine>Gartenstrasse 20</addrLine>
@@ -57,7 +57,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -105,7 +105,7 @@
                   <title xml:lang="po">Negy kis zongoradarab</title>
                   <respStmt>
                      <persName role="composer"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="DNB"
                                codedval="118573527">Franz Liszt</persName>
                      <persName role="editor">José Vianna da Motta</persName>
@@ -157,7 +157,7 @@
                </title>
                <respStmt>
                   <persName role="composer"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="DNB"
                             codedval="118573527">Franz Liszt</persName>
                   <persName role="dedicatee">Baroness Olga von

--- a/MEI_3.0/Music/Complete_examples/Liszt_Four_little_pieces.mei
+++ b/MEI_3.0/Music/Complete_examples/Liszt_Four_little_pieces.mei
@@ -34,10 +34,10 @@
                   <address>
                      <addrLine>Gartenstrasse 20</addrLine>
                      <addrLine>32756 <geogName codedval="7004442"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Detmold</geogName>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -63,12 +63,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -81,11 +81,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Lully_LaDescenteDeMars.mei
+++ b/MEI_3.0/Music/Complete_examples/Lully_LaDescenteDeMars.mei
@@ -11,7 +11,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="118575287"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Jean-Baptiste Lully</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -19,7 +19,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -48,7 +48,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
@@ -93,7 +93,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="118575287"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Jean-Baptiste Lully</persName>
                      <persName role="arranger">Michel Rondeau</persName>
                   </respStmt>
@@ -123,7 +123,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118575287"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Jean-Baptiste Lully</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Lully_LaDescenteDeMars.mei
+++ b/MEI_3.0/Music/Complete_examples/Lully_LaDescenteDeMars.mei
@@ -24,12 +24,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -53,12 +53,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -70,11 +70,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Mahler_Song.mei
+++ b/MEI_3.0/Music/Complete_examples/Mahler_Song.mei
@@ -20,12 +20,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -50,12 +50,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -68,11 +68,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Mahler_Song.mei
+++ b/MEI_3.0/Music/Complete_examples/Mahler_Song.mei
@@ -15,7 +15,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar (Detmold)</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar (Detmold)</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -44,7 +44,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -92,11 +92,11 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="118576291"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Gustav Mahler</persName>
                      <persName role="lyricist"
                                codedval="118576291"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Gustav Mahler</persName>
                   </respStmt>
                </titleStmt>
@@ -147,7 +147,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118576291"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Gustav Mahler</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Marney_BreakThouTheBreadOfLife.mei
+++ b/MEI_3.0/Music/Complete_examples/Marney_BreakThouTheBreadOfLife.mei
@@ -15,7 +15,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -44,7 +44,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>

--- a/MEI_3.0/Music/Complete_examples/Marney_BreakThouTheBreadOfLife.mei
+++ b/MEI_3.0/Music/Complete_examples/Marney_BreakThouTheBreadOfLife.mei
@@ -20,12 +20,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -49,12 +49,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -66,11 +66,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/McFerrin_Don't_worry.mei
+++ b/MEI_3.0/Music/Complete_examples/McFerrin_Don't_worry.mei
@@ -10,14 +10,14 @@
             <respStmt>
                <persName role="creator"
                          authority="GND"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          codedval="134451260 ">Bobby McFerrin</persName>
                <persName role="encoder">Maja Hartwig</persName>
             </respStmt>
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar Detmold</corpName>
+               <corpName role="publisher" codedval="5115204" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -42,7 +42,7 @@
                <corpName role="funder"
                          codedval="2007744-0"
                          authority="GND"
-                         authURI="http://d-nb.info/gnd">German Research Foundation
+                         authURI="http://d-nb.info/gnd/">German Research Foundation
                         <address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
@@ -80,11 +80,11 @@
                   <respStmt>
                      <persName role="composer"
                                authority="GND"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                codedval="134451260">Bobby Mc Ferrin</persName>
                      <persName role="lyricist"
                                authority="GND"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                codedval="134451260">Bobby Mc Ferrin</persName>
                   </respStmt>
                </titleStmt>
@@ -104,7 +104,7 @@
                <respStmt>
                   <persName role="composer"
                             authority="GND"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             codedval="134451260">Bobby McFerrin</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/McFerrin_Don't_worry.mei
+++ b/MEI_3.0/Music/Complete_examples/McFerrin_Don't_worry.mei
@@ -58,11 +58,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Mozart_DasVeilchen.mei
+++ b/MEI_3.0/Music/Complete_examples/Mozart_DasVeilchen.mei
@@ -19,10 +19,10 @@
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
-               <addrLine>32756 <geogName codedval="7004442" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Detmold</geogName>
+               <addrLine>32756 <geogName codedval="7004442" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
-                  <geogName codedval="7000084" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Germany</geogName>
+                  <geogName codedval="7000084" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Germany</geogName>
                </addrLine>
             </address>
             <date>2011</date>
@@ -43,10 +43,10 @@
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
-                        <geogName codedval="7005090" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Bonn</geogName>
+                        <geogName codedval="7005090" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
-                        <geogName codedval="7000084" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Germany</geogName>
+                        <geogName codedval="7000084" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
                </corpName>
@@ -55,9 +55,9 @@
                   Humanities<address>
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
-                        <geogName codedval="7013962" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Washington, DC</geogName> 20004</addrLine>
+                        <geogName codedval="7013962" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
-                        <geogName codedval="7012149" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">United States</geogName>
+                        <geogName codedval="7012149" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">United States</geogName>
                      </addrLine>
                   </address>
                </corpName>

--- a/MEI_3.0/Music/Complete_examples/Mozart_DasVeilchen.mei
+++ b/MEI_3.0/Music/Complete_examples/Mozart_DasVeilchen.mei
@@ -14,7 +14,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND"
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND"
                   >Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
@@ -38,7 +38,7 @@
             <title>MEI Sample Collection</title>
             <respStmt>
                <corpName role="publisher">MEI Project</corpName>
-               <corpName role="funder" codedval="2007744-0" authURI="http://d-nb.info/gnd"
+               <corpName role="funder" codedval="2007744-0" authURI="http://d-nb.info/gnd/"
                   authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -74,9 +74,9 @@
                <titleStmt>
                   <title>Das Veilchen</title>
                   <respStmt>
-                     <persName role="composer" codedval="118584596" authURI="http://d-nb.info/gnd"
+                     <persName role="composer" codedval="118584596" authURI="http://d-nb.info/gnd/"
                         authority="GND">Wolfgang Amadeus Mozart</persName>
-                     <persName role="lyricist" codedval="118540238" authURI="http://d-nb.info/gnd"
+                     <persName role="lyricist" codedval="118540238" authURI="http://d-nb.info/gnd/"
                         authority="GND">Johann Wolfgang von Goethe</persName>
                   </respStmt>
                </titleStmt>
@@ -105,9 +105,9 @@
             <titleStmt>
                <title>Das Veilchen</title>
                <respStmt>
-                  <persName role="composer" codedval="118584596" authURI="http://d-nb.info/gnd"
+                  <persName role="composer" codedval="118584596" authURI="http://d-nb.info/gnd/"
                      authority="GND">Wolfgang Amadeus Mozart</persName>
-                  <persName role="lyricist" codedval="118540238" authURI="http://d-nb.info/gnd"
+                  <persName role="lyricist" codedval="118540238" authURI="http://d-nb.info/gnd/"
                      authority="GND">Johann Wolfgang von Goethe</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Mozart_Fuge_G_minor.mei
+++ b/MEI_3.0/Music/Complete_examples/Mozart_Fuge_G_minor.mei
@@ -23,12 +23,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -53,12 +53,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -71,11 +71,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Mozart_Fuge_G_minor.mei
+++ b/MEI_3.0/Music/Complete_examples/Mozart_Fuge_G_minor.mei
@@ -10,7 +10,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="118584596"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Wolfgang Amadeus Mozart</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -18,7 +18,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -47,7 +47,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
 						Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -94,7 +94,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="118584596"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Wolfgang Amadeus
 								Mozart</persName>
                      <persName role="editor">Patrick Roose</persName>
@@ -136,7 +136,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118584596"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Wolfgang Amadeus Mozart</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Pachelbel_Canon_in_D.mei
+++ b/MEI_3.0/Music/Complete_examples/Pachelbel_Canon_in_D.mei
@@ -23,12 +23,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -52,12 +52,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -69,11 +69,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Pachelbel_Canon_in_D.mei
+++ b/MEI_3.0/Music/Complete_examples/Pachelbel_Canon_in_D.mei
@@ -10,7 +10,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="119456613"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Johann Pachelbel</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -18,7 +18,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -47,7 +47,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
@@ -91,7 +91,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="119456613"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Johann Pachelbel</persName>
                   </respStmt>
                </titleStmt>
@@ -118,7 +118,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="119456613"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Johann Pachelbel</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Parker-Gillespie_ShawNuff.mei
+++ b/MEI_3.0/Music/Complete_examples/Parker-Gillespie_ShawNuff.mei
@@ -27,10 +27,10 @@
                         <address>
                      <addrLine>Gartenstrasse 20</addrLine>
                      <addrLine>32756 <geogName codedval="7004442"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Detmold</geogName>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -56,12 +56,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -74,11 +74,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Parker-Gillespie_ShawNuff.mei
+++ b/MEI_3.0/Music/Complete_examples/Parker-Gillespie_ShawNuff.mei
@@ -9,7 +9,7 @@
             <title type="subordinate">an electronic transcription</title>
             <respStmt>
                <persName role="creator"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          codedval="118739328"
                          authority="GND">Charles Parker</persName>
                <persName role="creator">John Gillepsie</persName>
@@ -21,7 +21,7 @@
                <corpName role="publisher" n="2"
                          xml:id="corpName2"
                          codedval="5115204-6"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Musikwissenschaftliches
                         Seminar
                         <address>
@@ -50,7 +50,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
                         Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -99,7 +99,7 @@
                      <persName role="composer"
                                codedval="118739328"
                                authority="GND"
-                               authURI="http://d-nb.info/gnd">Charles Parker</persName>
+                               authURI="http://d-nb.info/gnd/">Charles Parker</persName>
                      <persName role="performer">John "Dizzy" Gillepsie</persName>
                   </respStmt>
                </titleStmt>
@@ -130,7 +130,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118739328"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Charles Parker</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Ponchielli_LarrivoDelRe.mei
+++ b/MEI_3.0/Music/Complete_examples/Ponchielli_LarrivoDelRe.mei
@@ -11,7 +11,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="119060507"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Amilcare Ponchielli</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -19,7 +19,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -48,7 +48,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -95,7 +95,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="119060507"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Amilcare Ponchielli</persName>
                      <persName role="editor">Henry Howey</persName>
                   </respStmt>
@@ -111,7 +111,7 @@
                   <respStmt>
                      <corpName role="publisher" codedval="10017434-6"
                                authority="GND"
-                               authURI="http://d-nb.info/gnd">Sam
+                               authURI="http://d-nb.info/gnd/">Sam
                         Houston State University (Huntsville, Tex.)</corpName>
                   </respStmt>
                   <address>
@@ -142,7 +142,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="119060507"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Amilcare Ponchielli</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Ponchielli_LarrivoDelRe.mei
+++ b/MEI_3.0/Music/Complete_examples/Ponchielli_LarrivoDelRe.mei
@@ -24,12 +24,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -54,12 +54,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -72,11 +72,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Praetorius_PuerNobisNascitur.mei
+++ b/MEI_3.0/Music/Complete_examples/Praetorius_PuerNobisNascitur.mei
@@ -24,12 +24,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -53,12 +53,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -70,11 +70,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Praetorius_PuerNobisNascitur.mei
+++ b/MEI_3.0/Music/Complete_examples/Praetorius_PuerNobisNascitur.mei
@@ -11,7 +11,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="118741713"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Michael Praetorius</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -19,7 +19,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -48,7 +48,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
@@ -93,7 +93,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="118741713"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Michael Praetorius</persName>
                      <persName role="arranger">Michel Rondeau</persName>
                   </respStmt>
@@ -129,7 +129,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118741713"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Michael Praetorius</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Ravel_Le_tombeau.mei
+++ b/MEI_3.0/Music/Complete_examples/Ravel_Le_tombeau.mei
@@ -22,12 +22,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -52,12 +52,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -70,11 +70,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Ravel_Le_tombeau.mei
+++ b/MEI_3.0/Music/Complete_examples/Ravel_Le_tombeau.mei
@@ -17,7 +17,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -46,7 +46,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -93,7 +93,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="118598651"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Maurice Ravel</persName>
                      <persName role="editor">Pierre Gouin</persName>
                   </respStmt>
@@ -138,7 +138,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118598651"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Maurice Ravel</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Rimsky-Korsakov_StringQuartet_B.mei
+++ b/MEI_3.0/Music/Complete_examples/Rimsky-Korsakov_StringQuartet_B.mei
@@ -23,12 +23,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -53,12 +53,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -71,11 +71,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Rimsky-Korsakov_StringQuartet_B.mei
+++ b/MEI_3.0/Music/Complete_examples/Rimsky-Korsakov_StringQuartet_B.mei
@@ -10,7 +10,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="118601067"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Nikolaj A. Rimskij-Korsakov</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -18,7 +18,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -47,7 +47,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -95,7 +95,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="118601067"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Nikolaj A. Rimskij-Korsakov</persName>
                      <persName role="editor">Martin Peckham</persName>
                   </respStmt>
@@ -127,7 +127,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118601067"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Nikolaj A. Rimskij-Korsakov</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Saint-Saens_LeCarnevalDesAnimmaux.mei
+++ b/MEI_3.0/Music/Complete_examples/Saint-Saens_LeCarnevalDesAnimmaux.mei
@@ -23,12 +23,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -53,12 +53,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -71,11 +71,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Saint-Saens_LeCarnevalDesAnimmaux.mei
+++ b/MEI_3.0/Music/Complete_examples/Saint-Saens_LeCarnevalDesAnimmaux.mei
@@ -10,7 +10,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="11875081X"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Camille Saint-Saens</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -18,7 +18,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -47,7 +47,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
 						Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -94,7 +94,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="11875081X"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Camille Saint-Saens</persName>
                      <persName role="arranger">Martin Packham</persName>
                   </respStmt>
@@ -124,7 +124,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="11875081X"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Camille Saint-Saens</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Scarlatti_Sonata_in_C_major.mei
+++ b/MEI_3.0/Music/Complete_examples/Scarlatti_Sonata_in_C_major.mei
@@ -15,7 +15,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -42,7 +42,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
@@ -88,7 +88,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="118804952"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Domenico Scarlatti</persName>
                   </respStmt>
                </titleStmt>
@@ -125,7 +125,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118804952"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Domenico Scarlatti</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Scarlatti_Sonata_in_C_major.mei
+++ b/MEI_3.0/Music/Complete_examples/Scarlatti_Sonata_in_C_major.mei
@@ -20,12 +20,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -47,12 +47,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -64,11 +64,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Schubert_Erlkönig.mei
+++ b/MEI_3.0/Music/Complete_examples/Schubert_Erlkönig.mei
@@ -47,12 +47,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -65,11 +65,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Schubert_Erlkönig.mei
+++ b/MEI_3.0/Music/Complete_examples/Schubert_Erlkönig.mei
@@ -10,7 +10,7 @@
             <title type="subordinate">an electronic transcription</title>
             <respStmt>
                <persName role="creator"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          codedval="118610961"
                          authority="GND">Franz Schubert</persName>
                <persName role="encoder">Maja Hartwig</persName>
@@ -18,7 +18,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar </corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar </corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -41,7 +41,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
                         Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -89,7 +89,7 @@
                      <persName role="composer"
                                codedval="118610961"
                                authority="GND"
-                               authURI="http://d-nb.info/gnd">Franz Schubert</persName>
+                               authURI="http://d-nb.info/gnd/">Franz Schubert</persName>
                      <persName role="lyricist">Johann Wolfgang von Goethe</persName>
                      <persName role="dedicatee">Moritz von Dietrichstein</persName>
                   </respStmt>
@@ -113,7 +113,7 @@
                   <persName role="composer"
                             codedval="118610961"
                             authority="GND"
-                            authURI="http://d-nb.info/gnd">Franz Schubert</persName>
+                            authURI="http://d-nb.info/gnd/">Franz Schubert</persName>
                </respStmt>
             </titleStmt>
             <key pname="g" mode="minor">g Minor</key>

--- a/MEI_3.0/Music/Complete_examples/Schubert_Lindenbaum.mei
+++ b/MEI_3.0/Music/Complete_examples/Schubert_Lindenbaum.mei
@@ -15,7 +15,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar &lt;Detmold&gt;
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar &lt;Detmold&gt;
             <address>
                      <addrLine>Gartenstrasse 20</addrLine>
                      <addrLine>32756 <geogName>Detmold</geogName>

--- a/MEI_3.0/Music/Complete_examples/Schumann_Landmann.mei
+++ b/MEI_3.0/Music/Complete_examples/Schumann_Landmann.mei
@@ -19,18 +19,18 @@
          <pubStmt>
             <respStmt>
                <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar &lt;<geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>&gt;</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -50,12 +50,12 @@
                   <address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>53175 <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -68,11 +68,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Schumann_Landmann.mei
+++ b/MEI_3.0/Music/Complete_examples/Schumann_Landmann.mei
@@ -11,14 +11,14 @@
             <respStmt>
                <persName role="creator"
                          codedval="118611666"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="Deusche Nationalbibliothek">Robert Schumann</persName>
                <persName role="encoder">Maja Hartwig</persName>
             </respStmt>
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar &lt;<geogName codedval="7004442"
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar &lt;<geogName codedval="7004442"
                             authURI="www.getty.edu/research/tools/vocabularies/tgn"
                             authority="TGN">Detmold</geogName>&gt;</corpName>
             </respStmt>
@@ -45,7 +45,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research Foundation
                   <address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -62,7 +62,7 @@
                </corpName>
                <corpName role="funder"
                          codedval="18183-3"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">National Endowment for the Humanities
                   <address>
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
@@ -91,7 +91,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="118611666"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="Deusche Nationalbibliothek">Robert Schumann</persName>
                   </respStmt>
                </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Schumann_Op.41.mei
+++ b/MEI_3.0/Music/Complete_examples/Schumann_Op.41.mei
@@ -11,7 +11,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="118611666"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Robert Schumann</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -19,7 +19,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -49,7 +49,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -97,7 +97,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="118611666"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Robert Schumann</persName>
                   </respStmt>
                </titleStmt>
@@ -189,11 +189,11 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118611666"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Robert Schumann</persName>
                   <persName role="dedicatee"
                             authority="GND"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             codedval="118580779">Felix Mendelssohn Bartholdy</persName>
                </respStmt>
             </titleStmt>
@@ -308,11 +308,11 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118611666"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Robert Schumann</persName>
                   <persName role="dedicatee"
                             authority="GND"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             codedval="118580779">Felix Mendelssohn Bartholdy</persName>
                </respStmt>
             </titleStmt>
@@ -430,11 +430,11 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118611666"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Robert Schumann</persName>
                   <persName role="dedicatee"
                             authority="GND"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             codedval="118580779">Felix Mendelssohn Bartholdy</persName>
                </respStmt>
             </titleStmt>
@@ -593,11 +593,11 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118611666"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Robert Schumann</persName>
                   <persName role="dedicatee"
                             authority="GND"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             codedval="118580779">Felix Mendelssohn Bartholdy</persName>
                </respStmt>
             </titleStmt>
@@ -764,11 +764,11 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118611666"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Robert Schumann</persName>
                   <persName role="dedicatee"
                             authority="GND"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             codedval="118580779">Felix Mendelssohn Bartholdy</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Schumann_Op.41.mei
+++ b/MEI_3.0/Music/Complete_examples/Schumann_Op.41.mei
@@ -24,12 +24,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -55,12 +55,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -73,11 +73,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Schumann_Song_Op48-1.mei
+++ b/MEI_3.0/Music/Complete_examples/Schumann_Song_Op48-1.mei
@@ -16,18 +16,18 @@
          <pubStmt>
             <respStmt>
                <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar &lt;<geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>&gt;</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -51,12 +51,12 @@
 						<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>53175 <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -69,11 +69,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Schumann_Song_Op48-1.mei
+++ b/MEI_3.0/Music/Complete_examples/Schumann_Song_Op48-1.mei
@@ -15,7 +15,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar &lt;<geogName codedval="7004442"
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar &lt;<geogName codedval="7004442"
                             authURI="www.getty.edu/research/tools/vocabularies/tgn"
                             authority="TGN">Detmold</geogName>&gt;</corpName>
             </respStmt>
@@ -46,7 +46,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research Foundation
 						<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -63,7 +63,7 @@
                </corpName>
                <corpName role="funder"
                          codedval="18183-3"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">National Endowment for the Humanities
 						<address>
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
@@ -95,11 +95,11 @@
                      <resp>von</resp>
                      <persName role="composer"
                                codedval="118611666"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="Deusche Nationalbibliothek">Robert Schumann</persName>
                      <persName role="lyricist"
                                codedval="118548018"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Heinrich Heine</persName>
                      <persName role="dedicatee">Wilhelmine Schröder-Devrient</persName>
                   </respStmt>
@@ -108,14 +108,14 @@
                   <respStmt>
                      <corpName role="publisher"
                                authority="GND"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                codedval="4098323-7">Verlag von Breitkopf &amp; Härtel in Leipzig</corpName>
                   </respStmt>
                   <respStmt>
                      <resp>Original-Verleger:</resp>
                      <corpName
                                authority="GND"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                codedval="4351303-7">C. F. Peters in Leipzig</corpName>
                   </respStmt>
                   <pubPlace>Leipzig</pubPlace>
@@ -130,7 +130,7 @@
                      <resp>herausgegeben von</resp>
                      <persName role="editor"
                                authority="GND"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                codedval="11861164X">Clara Schumann</persName>
                   </respStmt>
                   <seriesStmt>
@@ -186,7 +186,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118611666"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Robert Schumann</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Schutz_DomineDeus.mei
+++ b/MEI_3.0/Music/Complete_examples/Schutz_DomineDeus.mei
@@ -8,14 +8,14 @@
             <title type="subordinate">an electronic transcription</title>
             <respStmt>
                <persName role="creator" cert="unknown" codedval="11861116X"
-                  authURI="http://d-nb.info/gnd" authority="GND">Heinrich Schütz</persName>
+                  authURI="http://d-nb.info/gnd/" authority="GND">Heinrich Schütz</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
             </respStmt>
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND"
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND"
                   >Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
@@ -43,7 +43,7 @@
             <title>MEI Sample Collection</title>
             <respStmt>
                <corpName role="publisher">MEI Project</corpName>
-               <corpName role="funder" codedval="2007744-0" authURI="http://d-nb.info/gnd"
+               <corpName role="funder" codedval="2007744-0" authURI="http://d-nb.info/gnd/"
                   authority="GND">German Research Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
@@ -84,7 +84,7 @@
                <titleStmt>
                   <title>Domine Deus, Deus virtutum</title>
                   <respStmt>
-                     <persName role="creator" cert="unknown" codedval="11861116X" authURI="http://d-nb.info/gnd"
+                     <persName role="creator" cert="unknown" codedval="11861116X" authURI="http://d-nb.info/gnd/"
                         authority="GND">Heinrich Schütz</persName>
                      <persName role="editor">Fritz Brodersen</persName>
                   </respStmt>
@@ -110,7 +110,7 @@
             <titleStmt>
                <title>Domine Deus, Deus virtutum</title>
                <respStmt>
-                  <persName role="creator" cert="unknown" codedval="11861116X" authURI="http://d-nb.info/gnd"
+                  <persName role="creator" cert="unknown" codedval="11861116X" authURI="http://d-nb.info/gnd/"
                      authority="GND">Heinrich Schütz</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Schutz_DomineDeus.mei
+++ b/MEI_3.0/Music/Complete_examples/Schutz_DomineDeus.mei
@@ -21,12 +21,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                     authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
+                     authURI="http://vocab.getty.edu/page/tgn/" authority="TGN"
                      >Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                     authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
+                     authURI="http://vocab.getty.edu/page/tgn/" authority="TGN"
                      >Germany</geogName>
                </addrLine>
             </address>
@@ -48,12 +48,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                           authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
+                           authURI="http://vocab.getty.edu/page/tgn/" authority="TGN"
                            >Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                           authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
+                           authURI="http://vocab.getty.edu/page/tgn/" authority="TGN"
                            >Germany</geogName>
                      </addrLine>
                   </address>
@@ -63,11 +63,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                           authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
+                           authURI="http://vocab.getty.edu/page/tgn/" authority="TGN"
                            >Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                           authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
+                           authURI="http://vocab.getty.edu/page/tgn/" authority="TGN"
                            >United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Schutz_Jubilate_Deo.mei
+++ b/MEI_3.0/Music/Complete_examples/Schutz_Jubilate_Deo.mei
@@ -11,7 +11,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="11861116X"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Heinrich Schütz</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -19,7 +19,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -48,7 +48,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -96,7 +96,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="11861116X"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Heinrich Schütz</persName>
                      <persName role="arranger">Michel Rondeau</persName>
                   </respStmt>
@@ -126,7 +126,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="11861116X"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Heinrich Schütz</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Schutz_Jubilate_Deo.mei
+++ b/MEI_3.0/Music/Complete_examples/Schutz_Jubilate_Deo.mei
@@ -24,12 +24,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -54,12 +54,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -72,11 +72,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Telemann_Concert.mei
+++ b/MEI_3.0/Music/Complete_examples/Telemann_Concert.mei
@@ -11,7 +11,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="11862119X"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Georg Philipp Telemann</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -19,7 +19,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -48,7 +48,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
             Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -97,7 +97,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="11862119X"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Georg Philipp Telemann</persName>
                      <persName role="arranger">Michel Rondeau</persName>
                   </respStmt>
@@ -129,7 +129,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="11862119X"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Georg Philipp Telemann</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Telemann_Concert.mei
+++ b/MEI_3.0/Music/Complete_examples/Telemann_Concert.mei
@@ -24,12 +24,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -54,12 +54,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -72,11 +72,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Telemann_Suite.mei
+++ b/MEI_3.0/Music/Complete_examples/Telemann_Suite.mei
@@ -23,12 +23,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -53,12 +53,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -71,11 +71,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Telemann_Suite.mei
+++ b/MEI_3.0/Music/Complete_examples/Telemann_Suite.mei
@@ -10,7 +10,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="11862119X"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Georg Philipp Telemann</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -18,7 +18,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -47,7 +47,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
 						Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -95,7 +95,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="11862119X"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Georg Philipp Telemann</persName>
                      <persName role="arranger">Michel Rondeau</persName>
                   </respStmt>
@@ -129,7 +129,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="11862119X"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Georg Philipp Telemann</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Vivaldi_Op8_No.2.mei
+++ b/MEI_3.0/Music/Complete_examples/Vivaldi_Op8_No.2.mei
@@ -27,12 +27,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -57,12 +57,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -75,11 +75,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Vivaldi_Op8_No.2.mei
+++ b/MEI_3.0/Music/Complete_examples/Vivaldi_Op8_No.2.mei
@@ -14,7 +14,7 @@
             <respStmt>
                <persName role="creator"
                          codedval="118627287"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">Antonio Vivaldi</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -22,7 +22,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
@@ -51,7 +51,7 @@
                <corpName role="publisher">MEI Project</corpName>
                <corpName role="funder"
                          codedval="2007744-0"
-                         authURI="http://d-nb.info/gnd"
+                         authURI="http://d-nb.info/gnd/"
                          authority="GND">German Research
             Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -101,7 +101,7 @@
                   <respStmt>
                      <persName role="composer"
                                codedval="118627287"
-                               authURI="http://d-nb.info/gnd"
+                               authURI="http://d-nb.info/gnd/"
                                authority="GND">Antonio Vivaldi</persName>
                   </respStmt>
                </titleStmt>
@@ -182,7 +182,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118627287"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Antonio Vivaldi</persName>
                </respStmt>
             </titleStmt>
@@ -213,7 +213,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118627287"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Antonio Vivaldi</persName>
                </respStmt>
             </titleStmt>
@@ -244,7 +244,7 @@
                <respStmt>
                   <persName role="composer"
                             codedval="118627287"
-                            authURI="http://d-nb.info/gnd"
+                            authURI="http://d-nb.info/gnd/"
                             authority="GND">Antonio Vivaldi</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Weber_Arie.mei
+++ b/MEI_3.0/Music/Complete_examples/Weber_Arie.mei
@@ -8,7 +8,7 @@
                Rettung finden" (WeV D.2). Einlage zu "Héléna" von Étienne Nicolas Méhul</title>
             <title type="subordinate">an electronic transcription</title>
             <respStmt>
-               <persName role="creator" codedval="118629662" authURI="http://d-nb.info/gnd"
+               <persName role="creator" codedval="118629662" authURI="http://d-nb.info/gnd/"
                   authority="GND">Carl Maria von Weber</persName>
                <persName role="encoder">Maja Hartwig</persName>
                <persName role="encoder">Kristina Richts</persName>
@@ -16,7 +16,7 @@
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND"
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/" authority="GND"
                   >Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
@@ -44,7 +44,7 @@
             <title>MEI Sample Collection</title>
             <respStmt>
                <corpName role="publisher">MEI Project</corpName>
-               <corpName role="funder" codedval="2007744-0" authURI="http://d-nb.info/gnd"
+               <corpName role="funder" codedval="2007744-0" authURI="http://d-nb.info/gnd/"
                   authority="GND">German Research Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
@@ -86,7 +86,7 @@
                      ihn Rettung finden" (WeV D.2). Einlage zu "Héléna" von Étienne Nicolas
                      Méhul</title>
                   <respStmt>
-                     <persName role="composer" codedval="118629662" authURI="http://d-nb.info/gnd"
+                     <persName role="composer" codedval="118629662" authURI="http://d-nb.info/gnd/"
                         authority="GND">Carl Maria von Weber</persName>
                   </respStmt>
                </titleStmt>
@@ -112,7 +112,7 @@
             <titleStmt>
                <title>Scena (ed Aria)</title>
                <respStmt>
-                  <persName role="composer" codedval="118629662" authURI="http://d-nb.info/gnd"
+                  <persName role="composer" codedval="118629662" authURI="http://d-nb.info/gnd/"
                      authority="GND">Carl Maria von Weber</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Weber_Arie.mei
+++ b/MEI_3.0/Music/Complete_examples/Weber_Arie.mei
@@ -22,12 +22,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                     authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
+                     authURI="http://vocab.getty.edu/page/tgn/" authority="TGN"
                      >Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                     authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
+                     authURI="http://vocab.getty.edu/page/tgn/" authority="TGN"
                      >Germany</geogName>
                </addrLine>
             </address>
@@ -49,12 +49,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                           authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
+                           authURI="http://vocab.getty.edu/page/tgn/" authority="TGN"
                            >Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                           authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
+                           authURI="http://vocab.getty.edu/page/tgn/" authority="TGN"
                            >Germany</geogName>
                      </addrLine>
                   </address>
@@ -64,11 +64,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                           authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
+                           authURI="http://vocab.getty.edu/page/tgn/" authority="TGN"
                            >Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                           authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN"
+                           authURI="http://vocab.getty.edu/page/tgn/" authority="TGN"
                            >United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Music/Complete_examples/Webern_VariationsforPiano.mei
+++ b/MEI_3.0/Music/Complete_examples/Webern_VariationsforPiano.mei
@@ -8,14 +8,14 @@
             <title type="subordinate">op.27 (1936), second movement</title>
             <title type="subordinate">an electronic transcription</title>
             <respStmt>
-               <persName role="creator" authURI="http://d-nb.info/gnd" authority="GND"
+               <persName role="creator" authURI="http://d-nb.info/gnd/" authority="GND"
                   codedval="118629786">Anton Webern</persName>
                <persName role="encoder">Maja Hartwig</persName>
             </respStmt>
          </titleStmt>
          <pubStmt>
             <respStmt>
-               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd"
+               <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd/"
                   authority="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
             </respStmt>
             <address>
@@ -39,7 +39,7 @@
             <title>MEI Sample Collection</title>
             <respStmt>
                <corpName role="publisher">MEI Project</corpName>
-               <corpName role="funder" codedval="2007744-0" authURI="http://d-nb.info/gnd"
+               <corpName role="funder" codedval="2007744-0" authURI="http://d-nb.info/gnd/"
                   authority="GND">German Research
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
@@ -75,7 +75,7 @@
                   <title type="subordinate">op.27 (1936), second movement</title>
                   <title type="uniform">Variationen, Kl, op. 27 &lt;2. Satz&gt;</title>
                   <respStmt>
-                     <persName role="composer" authURI="http://d-nb.info/gnd" authority="GND"
+                     <persName role="composer" authURI="http://d-nb.info/gnd/" authority="GND"
                         codedval="118629786">Anton Webern</persName>
                   </respStmt>
                </titleStmt>
@@ -103,7 +103,7 @@
                <title type="subordinate">op.27 (1936), second movement</title>
                <title type="uniform">Variationen, Kl, op. 27 &lt;2. Satz&gt;</title>
                <respStmt>
-                  <persName role="composer" authURI="http://d-nb.info/gnd" authority="GND"
+                  <persName role="composer" authURI="http://d-nb.info/gnd/" authority="GND"
                      codedval="118629786">Anton Webern</persName>
                </respStmt>
             </titleStmt>

--- a/MEI_3.0/Music/Complete_examples/Webern_VariationsforPiano.mei
+++ b/MEI_3.0/Music/Complete_examples/Webern_VariationsforPiano.mei
@@ -20,10 +20,10 @@
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
-               <addrLine>32756 <geogName codedval="7004442" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Detmold</geogName>
+               <addrLine>32756 <geogName codedval="7004442" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
-                  <geogName codedval="7000084" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Germany</geogName>
+                  <geogName codedval="7000084" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Germany</geogName>
                </addrLine>
             </address>
             <date>2011</date>
@@ -44,10 +44,10 @@
                   Foundation<address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
-                        <geogName codedval="7005090" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Bonn</geogName>
+                        <geogName codedval="7005090" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
-                        <geogName codedval="7000084" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Germany</geogName>
+                        <geogName codedval="7000084" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
                </corpName>
@@ -56,9 +56,9 @@
                   Humanities<address>
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
-                        <geogName codedval="7013962" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">Washington, DC</geogName> 20004</addrLine>
+                        <geogName codedval="7013962" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
-                        <geogName codedval="7012149" authURI="www.getty.edu/research/tools/vocabularies/tgn" authority="TGN">United States</geogName>
+                        <geogName codedval="7012149" authURI="http://vocab.getty.edu/page/tgn/" authority="TGN">United States</geogName>
                      </addrLine>
                   </address>
                </corpName>

--- a/MEI_3.0/Musical-features/snippets/short_examples/ambig.mei
+++ b/MEI_3.0/Musical-features/snippets/short_examples/ambig.mei
@@ -14,12 +14,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -44,12 +44,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -62,11 +62,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Musical-features/snippets/short_examples/ambig2.mei
+++ b/MEI_3.0/Musical-features/snippets/short_examples/ambig2.mei
@@ -14,12 +14,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -44,12 +44,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -62,11 +62,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Musical-features/snippets/short_examples/artic.mei
+++ b/MEI_3.0/Musical-features/snippets/short_examples/artic.mei
@@ -14,12 +14,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -44,12 +44,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -62,11 +62,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Musical-features/snippets/short_examples/bidur.mei
+++ b/MEI_3.0/Musical-features/snippets/short_examples/bidur.mei
@@ -14,12 +14,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -44,12 +44,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -62,11 +62,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Musical-features/snippets/short_examples/break.mei
+++ b/MEI_3.0/Musical-features/snippets/short_examples/break.mei
@@ -14,12 +14,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -44,12 +44,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -62,11 +62,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Musical-features/snippets/short_examples/caution.mei
+++ b/MEI_3.0/Musical-features/snippets/short_examples/caution.mei
@@ -14,12 +14,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -44,12 +44,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -62,11 +62,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Musical-features/snippets/short_examples/chord_seconds.mei
+++ b/MEI_3.0/Musical-features/snippets/short_examples/chord_seconds.mei
@@ -15,18 +15,18 @@
             <respStmt>
                <corpName role="publisher" codedval="5115204-6" authURI="http://d-nb.info/gnd" authority="GND">Musikwissenschaftliches Seminar
                         &lt;<geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>&gt;</corpName>
             </respStmt>
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -50,12 +50,12 @@
                         <address>
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>53175 <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -69,11 +69,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Musical-features/snippets/short_examples/finger.mei
+++ b/MEI_3.0/Musical-features/snippets/short_examples/finger.mei
@@ -14,12 +14,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -44,12 +44,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -62,11 +62,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Musical-features/snippets/short_examples/finger2.mei
+++ b/MEI_3.0/Musical-features/snippets/short_examples/finger2.mei
@@ -14,12 +14,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -44,12 +44,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -62,11 +62,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Musical-features/snippets/short_examples/fractup.mei
+++ b/MEI_3.0/Musical-features/snippets/short_examples/fractup.mei
@@ -14,12 +14,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -44,12 +44,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -62,11 +62,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Musical-features/snippets/short_examples/fturn.mei
+++ b/MEI_3.0/Musical-features/snippets/short_examples/fturn.mei
@@ -14,12 +14,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -44,12 +44,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -62,11 +62,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Musical-features/snippets/short_examples/grace.mei
+++ b/MEI_3.0/Musical-features/snippets/short_examples/grace.mei
@@ -14,12 +14,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -44,12 +44,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -62,11 +62,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Musical-features/snippets/short_examples/keytime.mei
+++ b/MEI_3.0/Musical-features/snippets/short_examples/keytime.mei
@@ -14,12 +14,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -44,12 +44,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -62,11 +62,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Musical-features/snippets/short_examples/lhrh.mei
+++ b/MEI_3.0/Musical-features/snippets/short_examples/lhrh.mei
@@ -14,12 +14,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -44,12 +44,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -62,11 +62,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Musical-features/snippets/short_examples/lhrh2.mei
+++ b/MEI_3.0/Musical-features/snippets/short_examples/lhrh2.mei
@@ -14,12 +14,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -44,12 +44,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -62,11 +62,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Musical-features/snippets/short_examples/lhrh3.mei
+++ b/MEI_3.0/Musical-features/snippets/short_examples/lhrh3.mei
@@ -14,12 +14,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -44,12 +44,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -62,11 +62,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Musical-features/snippets/short_examples/lhrh4.mei
+++ b/MEI_3.0/Musical-features/snippets/short_examples/lhrh4.mei
@@ -14,12 +14,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -44,12 +44,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -62,11 +62,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Musical-features/snippets/short_examples/nested.mei
+++ b/MEI_3.0/Musical-features/snippets/short_examples/nested.mei
@@ -14,12 +14,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -44,12 +44,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -62,11 +62,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Musical-features/snippets/short_examples/secondary.mei
+++ b/MEI_3.0/Musical-features/snippets/short_examples/secondary.mei
@@ -14,12 +14,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -44,12 +44,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -62,11 +62,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Musical-features/snippets/short_examples/trill.mei
+++ b/MEI_3.0/Musical-features/snippets/short_examples/trill.mei
@@ -14,12 +14,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -44,12 +44,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -62,11 +62,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Musical-features/snippets/short_examples/x3staff.mei
+++ b/MEI_3.0/Musical-features/snippets/short_examples/x3staff.mei
@@ -14,12 +14,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -44,12 +44,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -62,11 +62,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>

--- a/MEI_3.0/Musical-features/snippets/short_examples/xchord.mei
+++ b/MEI_3.0/Musical-features/snippets/short_examples/xchord.mei
@@ -14,12 +14,12 @@
             <address>
                <addrLine>Gartenstrasse 20</addrLine>
                <addrLine>32756 <geogName codedval="7004442"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Detmold</geogName>
                </addrLine>
                <addrLine>
                   <geogName codedval="7000084"
-                            authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                            authURI="http://vocab.getty.edu/page/tgn/"
                             authority="TGN">Germany</geogName>
                </addrLine>
             </address>
@@ -44,12 +44,12 @@
                      <addrLine>Kennedyallee 40</addrLine>
                      <addrLine>
                         <geogName codedval="7005090"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Bonn</geogName>
                      </addrLine>
                      <addrLine>
                         <geogName codedval="7000084"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Germany</geogName>
                      </addrLine>
                   </address>
@@ -62,11 +62,11 @@
                      <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
                      <addrLine>
                         <geogName codedval="7013962"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">Washington, DC</geogName> 20004</addrLine>
                      <addrLine>
                         <geogName codedval="7012149"
-                                  authURI="www.getty.edu/research/tools/vocabularies/tgn"
+                                  authURI="http://vocab.getty.edu/page/tgn/"
                                   authority="TGN">United States</geogName>
                      </addrLine>
                   </address>


### PR DESCRIPTION
This commit fixes authority file references to GND and TGN in MEI_3.0 example files.