### PR TITLE
updated Maple Leaf Rag

### DIFF
--- a/MEI_4.0/Music/Complete_examples/Joplin_Maple_leaf_Rag.mei
+++ b/MEI_4.0/Music/Complete_examples/Joplin_Maple_leaf_Rag.mei
@@ -232,7 +232,7 @@
         </changeDesc>
         <date isodate="2015-10-16" />
       </change>
-      <change n="8">
+      <change n="9">
         <changeDesc>
           <p>Converted to version 3.0.0 using mei21To30.xsl, version 1.0 beta</p>
         </changeDesc>
@@ -622,7 +622,6 @@
               <staff n="1">
                 <layer n="1">
                   <mRest xml:id="d1e2297" dur="2" dur.ppq="8" />
-                  <space xml:id="d1e2498" dur="8" dur.ppq="2" />
                 </layer>
               </staff>
               <staff n="2">
@@ -2481,7 +2480,6 @@
               <staff n="1">
                 <layer n="1">
                   <mRest xml:id="d1e15277" dur="2" dur.ppq="8" />
-                  <space xml:id="d1e15485" dur="8" dur.ppq="2" />
                 </layer>
               </staff>
               <staff n="2">

--- a/MEI_4.0/Music/Complete_examples/Joplin_Maple_leaf_Rag.mei
+++ b/MEI_4.0/Music/Complete_examples/Joplin_Maple_leaf_Rag.mei
@@ -1,15 +1,16 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?xml-model href="http://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="http://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" xmlns:xlink="http://www.w3.org/1999/xlink"
-  meiversion="4.0.0">
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
+<?xml-model href="http://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
     <fileDesc>
       <titleStmt>
-        <title>Maple Leaf Rag <titlePart type="subordinate">an electronic transcription</titlePart> </title>
+        <title>
+          Maple Leaf Rag
+          <titlePart type="subordinate">an electronic transcription</titlePart>
+        </title>
         <composer>
-          <persName role="creator" codedval="119174030" auth.uri="http://d-nb.info/gnd/" auth="GND"
-            >Scott Joplin</persName>
+          <persName role="creator" codedval="119174030" auth.uri="http://d-nb.info/gnd/" auth="GND">Scott Joplin</persName>
         </composer>
         <respStmt>
           <persName role="encoder">Maja Hartwig</persName>
@@ -18,62 +19,69 @@
       </titleStmt>
       <pubStmt>
         <publisher>
-          <corpName role="publisher" codedval="5115204-6" auth.uri="http://d-nb.info/gnd/"
-            auth="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
+          <corpName role="publisher" codedval="5115204-6" auth.uri="http://d-nb.info/gnd/" auth="GND">Musikwissenschaftliches Seminar, Detmold</corpName>
         </publisher>
         <address>
           <addrLine>Gartenstrasse 20</addrLine>
-          <addrLine>32756 <geogName codedval="7004442" auth.uri="http://vocab.getty.edu/page/tgn/"
-            auth="TGN">Detmold</geogName> </addrLine>
           <addrLine>
-            <geogName codedval="7000084" auth.uri="http://vocab.getty.edu/page/tgn/" auth="TGN"
-              >Germany</geogName>
+            32756
+            <geogName codedval="7004442" auth.uri="http://vocab.getty.edu/page/tgn/" auth="TGN">Detmold</geogName>
+          </addrLine>
+          <addrLine>
+            <geogName codedval="7000084" auth.uri="http://vocab.getty.edu/page/tgn/" auth="TGN">Germany</geogName>
           </addrLine>
         </address>
         <date>2011</date>
         <availability>
-          <useRestrict>This encoding is in the public domain. However, the sources used to create it
-            may be under copyright. We believe their use by the MEI project for educational and
-            research purposes is covered by the Fair Use doctrine. However, we will remove any
-            material from the project archive when requested to do so by the copyright
-            owner.</useRestrict>
+          <useRestrict>This encoding is in the public domain. However, the sources used to create it may be under copyright. We believe their use by the MEI project for educational and research purposes is covered by the Fair Use doctrine. However, we will
+            remove any material from the project archive when requested to do so by the copyright owner.</useRestrict>
         </availability>
       </pubStmt>
       <seriesStmt>
         <title>MEI Sample Collection</title>
         <funder>
-          <corpName role="funder" codedval="2007744-0" auth.uri="http://d-nb.info/gnd/" auth="GND"
-            >German Research Foundation<address> <addrLine>Kennedyallee 40</addrLine> <addrLine>
-            <geogName codedval="7005090" auth.uri="http://vocab.getty.edu/page/tgn/" auth="TGN"
-            >Bonn</geogName> </addrLine> <addrLine> <geogName codedval="7000084"
-            auth.uri="http://vocab.getty.edu/page/tgn/" auth="TGN">Germany</geogName> </addrLine>
-            </address> </corpName>
+          <corpName role="funder" codedval="2007744-0" auth.uri="http://d-nb.info/gnd/" auth="GND">
+            German Research Foundation
+            <address>
+              <addrLine>Kennedyallee 40</addrLine>
+              <addrLine>
+                <geogName codedval="7005090" auth.uri="http://vocab.getty.edu/page/tgn/" auth="TGN">Bonn</geogName>
+              </addrLine>
+              <addrLine>
+                <geogName codedval="7000084" auth.uri="http://vocab.getty.edu/page/tgn/" auth="TGN">Germany</geogName>
+              </addrLine>
+            </address>
+          </corpName>
         </funder>
         <funder>
-          <corpName role="funder" codedval="18183-3" auth.uri="http://d-nb.info/gnd/18183-3"
-            auth="Deutsche Nationalbibliothek">National Endowment for the Humanities<address>
-            <addrLine>1100 Pennsylvania Avenue N.W.</addrLine> <addrLine> <geogName
-            codedval="7013962" auth.uri="http://vocab.getty.edu/page/tgn/" auth="TGN">Washington,
-            DC</geogName> 20004</addrLine> <addrLine> <geogName codedval="7012149"
-            auth.uri="http://vocab.getty.edu/page/tgn/" auth="TGN">United States</geogName>
-            </addrLine> </address> </corpName>
+          <corpName role="funder" codedval="18183-3" auth.uri="http://d-nb.info/gnd/18183-3" auth="Deutsche Nationalbibliothek">
+            National Endowment for the Humanities
+            <address>
+              <addrLine>1100 Pennsylvania Avenue N.W.</addrLine>
+              <addrLine>
+                <geogName codedval="7013962" auth.uri="http://vocab.getty.edu/page/tgn/" auth="TGN">Washington, DC</geogName>
+                20004
+              </addrLine>
+              <addrLine>
+                <geogName codedval="7012149" auth.uri="http://vocab.getty.edu/page/tgn/" auth="TGN">United States</geogName>
+              </addrLine>
+            </address>
+          </corpName>
         </funder>
         <respStmt>
           <corpName role="publisher">MEI Project</corpName>
         </respStmt>
         <identifier>
-          <ref target="http://music-encoding.org/Support/MEI_Sample_Collection"/>
+          <ref target="http://music-encoding.org/Support/MEI_Sample_Collection" />
         </identifier>
       </seriesStmt>
       <sourceDesc>
         <source>
           <bibl>
-            <identifier type="URI"
-              >http://www.sheetmusicdigital.com/pdfopen.asp?ID=DL10000075</identifier>
+            <identifier type="URI">http://www.sheetmusicdigital.com/pdfopen.asp?ID=DL10000075</identifier>
             <title>Maple Leaf Rag</title>
             <composer>
-              <persName role="composer" codedval="119174030" auth.uri="http://d-nb.info/gnd/"
-                auth="GND">Scott Joplin</persName>
+              <persName role="composer" codedval="119174030" auth.uri="http://d-nb.info/gnd/" auth="GND">Scott Joplin</persName>
             </composer>
             <respStmt>
               <persName role="dedicatee">The Maple Leaf Club</persName>
@@ -96,8 +104,7 @@
       </appInfo>
       <classDecls>
         <taxonomy>
-          <bibl xml:id="OCLC_DDC"
-            target="http://www.oclc.org/dewey/resources/summaries/default.htm#700">OCLC_DDC</bibl>
+          <bibl xml:id="OCLC_DDC" target="http://www.oclc.org/dewey/resources/summaries/default.htm#700">OCLC_DDC</bibl>
           <category xml:id="_786.2">
             <altId>786.2</altId>
             <label>Piano</label>
@@ -124,11 +131,10 @@
       <work>
         <title>Maple Leaf Rag</title>
         <composer>
-          <persName role="composer" codedval="119174030" auth.uri="http://d-nb.info/gnd/" auth="GND"
-            >Scott Joplin</persName>
+          <persName role="composer" codedval="119174030" auth.uri="http://d-nb.info/gnd/" auth="GND">Scott Joplin</persName>
         </composer>
         <key pname="a" accid="f" mode="major">As-Dur</key>
-        <meter count="2" unit="4"/>
+        <meter count="2" unit="4" />
         <tempo>Tempo di marcia</tempo>
         <incip>
           <incipCode form="parsons">*uduududuu</incipCode>
@@ -154,43 +160,56 @@
     <revisionDesc>
       <change n="1">
         <changeDesc>
-          <p>The original MusicXML file was generated using PDFtoMusic Pro v1.2.1d Build 9F9F (c)
-            Myriad - http://www.myriad-online.com.</p>
+          <p>The original MusicXML file was generated using PDFtoMusic Pro v1.2.1d Build 9F9F (c) Myriad - http://www.myriad-online.com.</p>
         </changeDesc>
-        <date/>
+        <date />
       </change>
       <change n="2">
         <respStmt>
-          <persName xml:id="MH"> Maja Hartwig </persName>
+          <persName xml:id="MH">
+            Maja Hartwig
+          </persName>
         </respStmt>
         <changeDesc>
-          <p>Transcoded from a MusicXML version 1.1 file on 2011-05-12 using the <ref
-            target="#xsl_mxl2mei_2.2.3">musicxml2mei</ref> stylesheet. </p>
+          <p>
+            Transcoded from a MusicXML version 1.1 file on 2011-05-12 using the
+            <ref target="#xsl_mxl2mei_2.2.3">musicxml2mei</ref>
+            stylesheet.
+          </p>
         </changeDesc>
-        <date isodate="2011-05-12"/>
+        <date isodate="2011-05-12" />
       </change>
       <change n="3">
         <respStmt>
-          <persName xml:id="KR"> Kristina Richts </persName>
+          <persName xml:id="KR">
+            Kristina Richts
+          </persName>
         </respStmt>
         <changeDesc>
-          <p> Cleaned up MEI file automatically using <ref target="#xsl_ppq">ppq.xsl</ref>. </p>
+          <p>
+            Cleaned up MEI file automatically using
+            <ref target="#xsl_ppq">ppq.xsl</ref>
+            .
+          </p>
         </changeDesc>
-        <date isodate="2011-10-21"/>
+        <date isodate="2011-10-21" />
       </change>
       <change n="4" resp="#MH">
         <changeDesc>
           <p>change of staffgrp</p>
           <p>deletion of @stem.y, @ho and @vo</p>
         </changeDesc>
-        <date isodate="2011-10-20"/>
+        <date isodate="2011-10-20" />
       </change>
       <change n="5" resp="#KR">
         <changeDesc>
-          <p> Cleaned up MEI file automatically using <ref target="#xsl_header">Header.xsl</ref>.
+          <p>
+            Cleaned up MEI file automatically using
+            <ref target="#xsl_header">Header.xsl</ref>
+            .
           </p>
         </changeDesc>
-        <date isodate="2011-12-01"/>
+        <date isodate="2011-12-01" />
       </change>
       <change n="6">
         <respStmt>
@@ -199,33 +218,49 @@
         <changeDesc>
           <p>Revised the header.</p>
         </changeDesc>
-        <date isodate="2013-01-28"/>
+        <date isodate="2013-01-28" />
       </change>
       <change n="7">
         <changeDesc>
           <p>Converted to MEI 2013 using mei2012To2013.xsl, version 1.0 beta</p>
         </changeDesc>
-        <date isodate="2014-06-02"/>
+        <date isodate="2014-06-02" />
       </change>
       <change n="8">
         <changeDesc>
-          <p>File corrupted; imported MusicXML file into MuseScore, corrected minor errors and page
-            layout where different from original PDF, exported as MusicXML and converted to MEI
-            2013.</p>
+          <p>File corrupted; imported MusicXML file into MuseScore, corrected minor errors and page layout where different from original PDF, exported as MusicXML and converted to MEI 2013.</p>
         </changeDesc>
-        <date isodate="2015-10-16"/>
+        <date isodate="2015-10-16" />
       </change>
       <change n="8">
         <changeDesc>
           <p>Converted to version 3.0.0 using mei21To30.xsl, version 1.0 beta</p>
         </changeDesc>
-        <date isodate="2015-10-16"/>
+        <date isodate="2015-10-16" />
       </change>
       <change n="10" resp="#app_20193103955363">
         <changeDesc>
           <p>Converted to MEI version 4.0.0 using mei30To40.xsl, version 1.0 beta</p>
         </changeDesc>
-        <date isodate="2019-01-03"/>
+        <date isodate="2019-01-03" />
+      </change>
+      <change n="11">
+        <respStmt>
+          <persName>Klaus Rettinghaus</persName>
+        </respStmt>
+        <changeDesc>
+          <p>
+            Manually corrected after first edition:
+            <list>
+              <li>Changed doubled accid attribute on note to accid.ges.</li>
+              <li>Removed tie attributes.</li>
+              <li>Fixed clef changes.</li>
+              <li>Added missing rests.</li>
+              <li>Removed unnessesary scoreDefs.</li>
+            </list>
+          </p>
+        </changeDesc>
+        <date isodate="2020-12-01" />
       </change>
     </revisionDesc>
   </meiHead>
@@ -233,71 +268,61 @@
     <body>
       <mdiv>
         <score>
-          <scoreDef ppq="4" meter.count="2" meter.unit="4" key.sig="4f" key.mode="major"
-            text.name="FreeSerif" text.size="10pt" lyric.name="FreeSerif" lyric.size="11pt"
-            vu.height="0.75mm" page.height="372.534" page.width="287.866" page.leftmar="11.644"
-            page.rightmar="11.644" page.topmar="20.288" page.botmar="20.288">
+          <scoreDef ppq="4" meter.count="2" meter.unit="4" key.sig="4f" key.mode="major" text.name="FreeSerif" text.size="10pt" lyric.name="FreeSerif" lyric.size="11pt" vu.height="0.75mm" page.height="372.534" page.width="287.866" page.leftmar="11.644" page.rightmar="11.644" page.topmar="20.288" page.botmar="20.288">
             <pgHead>
-              <anchoredText x="276.222" y="335.006">
-                <rend fontsize="12pt" halign="right" valign="bottom">Scott Joplin</rend>
-              </anchoredText>
               <anchoredText x="143.933" y="352.246">
-                <rend fontsize="24pt" halign="center" valign="top">Maple Leaf Rag</rend>
+                <rend fontsize="24pt" halign="center" valign="top">MAPLE LEAF RAG.</rend>
+              </anchoredText>
+              <anchoredText x="276.222" y="335.006">
+                <rend fontsize="12pt" halign="right" valign="bottom">BY SCOTT JOPLIN.</rend>
               </anchoredText>
             </pgHead>
             <staffGrp>
               <staffGrp xml:id="P1" symbol="brace">
-                <label>Piano</label>
-                <instrDef xml:id="P1-I1" midi.channel="1" midi.volume="99" midi.pan="64"
-                  midi.instrnum="0"/>
-                <staffDef n="1" lines="5" clef.line="2" clef.shape="G"/>
-                <staffDef n="2" lines="5" clef.line="4" clef.shape="F" spacing="13"/>
+                <instrDef xml:id="P1-I1" midi.channel="1" midi.volume="99" midi.pan="64" midi.instrnum="0" />
+                <staffDef n="1" lines="5" clef.line="2" clef.shape="G" />
+                <staffDef n="2" lines="5" clef.line="4" clef.shape="F" spacing="13" />
               </staffGrp>
             </staffGrp>
           </scoreDef>
           <section>
-            <scoreDef system.leftmar="4.2" system.rightmar="0" system.topmar="31.24"/>
-            <measure n="1" xml:id="d1e58" right="rptstart" width="40.224">
+            <measure n="1" xml:id="d1e58" right="rptstart" width="40.224" metcon="false">
               <staff n="1">
                 <layer n="1">
-                  <rest xml:id="d1e103" dur="8" dur.ppq="2"/>
+                  <rest xml:id="d1e103" dur="8" dur.ppq="2" />
                 </layer>
               </staff>
               <staff n="2">
                 <layer n="1">
                   <chord xml:id="d19e1" dur="8" dur.ppq="2" stem.dir="up">
-                    <note xml:id="d1e116" pname="e" oct="2" accid.ges="f"/>
-                    <note xml:id="d1e134" pname="e" oct="3" accid.ges="f"/>
+                    <note xml:id="d1e116" pname="e" oct="2" accid.ges="f" />
+                    <note xml:id="d1e134" pname="e" oct="3" accid.ges="f" />
                   </chord>
                 </layer>
               </staff>
-              <tempo tstamp="1" place="above" staff="1" label="words">Tempo di marcia</tempo>
+              <tempo tstamp="1" place="above" staff="1" label="words">Tempo di marcia.</tempo>
             </measure>
           </section>
           <section>
             <measure n="2" xml:id="d1e153" left="rptstart" width="54.474">
               <staff n="1">
                 <layer n="1">
-                  <rest xml:id="d1e159" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e159" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e169" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e169" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1" stem.dir="up" accid.ges="f" />
                     <chord xml:id="d38e1" dur="16" dur.ppq="1" stem.dir="up" beam="m1">
-                      <note xml:id="d1e191" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e213" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e191" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e213" pname="e" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e232" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e232" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1" stem.dir="up" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e254" pname="c" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="up"/>
+                    <note xml:id="d1e254" pname="c" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="up" />
                     <chord xml:id="d46e1" dur="8" dur.ppq="2" stem.dir="up" beam="m1">
-                      <note xml:id="d1e274" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e294" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e274" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e294" pname="e" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e313" pname="g" oct="4" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="up"/>
+                    <note xml:id="d1e313" pname="g" oct="4" dur="16" dur.ppq="1" beam="t1" stem.dir="up" />
                   </beam>
                 </layer>
               </staff>
@@ -305,27 +330,27 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d53e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e344" pname="a" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e364" pname="a" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e344" pname="a" oct="2" accid.ges="f" />
+                      <note xml:id="d1e364" pname="a" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d59e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e383" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e403" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e422" pname="c" oct="4"/>
+                      <note xml:id="d1e383" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e403" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e422" pname="c" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d66e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e439" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e459" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e478" pname="c" oct="4"/>
+                      <note xml:id="d1e439" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e459" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e478" pname="c" oct="4" />
                     </chord>
                     <chord xml:id="d73e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e495" pname="a" accid="n" oct="2">
-                        <accid accid="n"/>
+                      <note xml:id="d1e495" pname="a" accid.ges="n" oct="2">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e515" pname="a" accid="n" oct="3">
-                        <accid accid="n"/>
+                      <note xml:id="d1e515" pname="a" accid.ges="n" oct="3">
+                        <accid accid="n" />
                       </note>
                     </chord>
                   </beam>
@@ -338,21 +363,19 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d104e1" dur="16" dur.ppq="1" stem.dir="up" beam="i1">
-                      <note xml:id="d1e536" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e558" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e536" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e558" pname="e" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e577" pname="g" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="up"/>
-                    <note xml:id="d1e597" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="up" accid.ges="f"/>
-                    <chord xml:id="d112e1" dur="16" dur.ppq="1" stem.dir="up" beam="t1" tie="i">
-                      <note xml:id="d1e619" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e644" pname="e" oct="5" accid.ges="f"/>
+                    <note xml:id="d1e577" pname="g" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="up" />
+                    <note xml:id="d1e597" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="up" accid.ges="f" />
+                    <chord xml:id="d112e1" dur="16" dur.ppq="1" stem.dir="up" beam="t1">
+                      <note xml:id="d1e619" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e644" pname="e" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
-                  <chord xml:id="d118e1" dur="4" dur.ppq="4" stem.dir="up" tie="t">
-                    <note xml:id="d1e666" pname="e" oct="4" accid.ges="f"/>
-                    <note xml:id="d1e687" pname="e" oct="5" accid.ges="f"/>
+                  <chord xml:id="d118e1" dur="4" dur.ppq="4" stem.dir="up">
+                    <note xml:id="d1e666" pname="e" oct="4" accid.ges="f" />
+                    <note xml:id="d1e687" pname="e" oct="5" accid.ges="f" />
                   </chord>
                 </layer>
               </staff>
@@ -360,56 +383,50 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d124e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e712" pname="b" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e732" pname="b" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e712" pname="b" oct="2" accid.ges="f" />
+                      <note xml:id="d1e732" pname="b" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d130e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e752" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e772" pname="g" oct="3"/>
-                      <note xml:id="d1e789" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e752" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e772" pname="g" oct="3" />
+                      <note xml:id="d1e789" pname="d" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d137e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e808" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e828" pname="g" oct="3"/>
-                      <note xml:id="d1e845" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e808" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e828" pname="g" oct="3" />
+                      <note xml:id="d1e845" pname="d" oct="4" accid.ges="f" />
                     </chord>
                     <chord xml:id="d144e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e864" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e884" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e864" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e884" pname="e" oct="3" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="1.75" startid="#d1e619" curvedir="below" tstamp2="0m+2" endid="#d1e666"
-                staff="1"/>
-              <tie tstamp="1.75" startid="#d1e644" curvedir="below" tstamp2="0m+2" endid="#d1e687"
-                staff="1"/>
+              <tie tstamp="1.75" startid="#d1e619" curvedir="below" tstamp2="0m+2" endid="#d1e666" staff="1" />
+              <tie tstamp="1.75" startid="#d1e644" curvedir="above" tstamp2="0m+2" endid="#d1e687" staff="1" />
             </measure>
             <measure n="4" xml:id="d1e903" width="54.474">
               <staff n="1">
                 <layer n="1">
-                  <rest xml:id="d1e905" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e905" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e915" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e915" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1" stem.dir="up" accid.ges="f" />
                     <chord xml:id="d180e1" dur="16" dur.ppq="1" stem.dir="up" beam="m1">
-                      <note xml:id="d1e937" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e959" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e937" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e959" pname="e" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e978" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e978" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1" stem.dir="up" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e1000" pname="c" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="up"/>
+                    <note xml:id="d1e1000" pname="c" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="up" />
                     <chord xml:id="d188e1" dur="8" dur.ppq="2" stem.dir="up" beam="m1">
-                      <note xml:id="d1e1020" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e1040" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e1020" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e1040" pname="e" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e1059" pname="g" oct="4" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="up"/>
+                    <note xml:id="d1e1059" pname="g" oct="4" dur="16" dur.ppq="1" beam="t1" stem.dir="up" />
                   </beam>
                 </layer>
               </staff>
@@ -417,27 +434,27 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d195e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e1082" pname="a" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e1103" pname="a" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e1082" pname="a" oct="2" accid.ges="f" />
+                      <note xml:id="d1e1103" pname="a" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d201e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e1122" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e1142" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e1161" pname="c" oct="4"/>
+                      <note xml:id="d1e1122" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e1142" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e1161" pname="c" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d208e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e1178" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e1198" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e1217" pname="c" oct="4"/>
+                      <note xml:id="d1e1178" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e1198" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e1217" pname="c" oct="4" />
                     </chord>
                     <chord xml:id="d215e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e1234" pname="a" accid="n" oct="2">
-                        <accid accid="n"/>
+                      <note xml:id="d1e1234" pname="a" accid.ges="n" oct="2">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e1254" pname="a" accid="n" oct="3">
-                        <accid accid="n"/>
+                      <note xml:id="d1e1254" pname="a" accid.ges="n" oct="3">
+                        <accid accid="n" />
                       </note>
                     </chord>
                   </beam>
@@ -449,27 +466,25 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d244e1" dur="16" dur.ppq="1" stem.dir="up" beam="i1">
-                      <note xml:id="d1e1275" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e1297" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e1275" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e1297" pname="e" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e1316" pname="g" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="up"/>
-                    <note xml:id="d1e1336" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="up" accid.ges="f"/>
-                    <chord xml:id="d252e1" dur="16" dur.ppq="1" stem.dir="up" beam="t1" tie="i">
-                      <note xml:id="d1e1358" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e1383" pname="e" oct="5" accid.ges="f"/>
+                    <note xml:id="d1e1316" pname="g" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="up" />
+                    <note xml:id="d1e1336" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="up" accid.ges="f" />
+                    <chord xml:id="d252e1" dur="16" dur.ppq="1" stem.dir="up" beam="t1">
+                      <note xml:id="d1e1358" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e1383" pname="e" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
-                    <chord xml:id="d258e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1" tie="t">
-                      <note xml:id="d1e1405" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e1428" pname="e" oct="5" accid.ges="f"/>
+                    <chord xml:id="d258e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
+                      <note xml:id="d1e1405" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e1428" pname="e" oct="5" accid.ges="f" />
                     </chord>
-                    <rest xml:id="d1e1450" dur="16" dur.ppq="1" beam="m1"/>
+                    <rest xml:id="d1e1450" dur="16" dur.ppq="1" beam="m1" />
                     <chord xml:id="d266e1" dur="16" dur.ppq="1" stem.dir="up" beam="t1">
-                      <note xml:id="d1e1460" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e1482" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e1460" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e1482" pname="e" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -478,71 +493,60 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d272e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e1505" pname="b" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e1525" pname="b" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e1505" pname="b" oct="2" accid.ges="f" />
+                      <note xml:id="d1e1525" pname="b" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d278e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e1544" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e1564" pname="g" oct="3"/>
-                      <note xml:id="d1e1581" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e1544" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e1564" pname="g" oct="3" />
+                      <note xml:id="d1e1581" pname="d" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d285e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e1600" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e1620" pname="g" oct="3"/>
-                      <note xml:id="d1e1637" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e1600" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e1620" pname="g" oct="3" />
+                      <note xml:id="d1e1637" pname="d" oct="4" accid.ges="f" />
                     </chord>
                     <chord xml:id="d292e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e1656" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e1676" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e1656" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e1676" pname="e" oct="3" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="1.75" startid="#d1e1358" curvedir="below" tstamp2="0m+2" endid="#d1e1405"
-                staff="1"/>
-              <tie tstamp="1.75" startid="#d1e1383" curvedir="below" tstamp2="0m+2" endid="#d1e1428"
-                staff="1"/>
+              <tie tstamp="1.75" startid="#d1e1358" curvedir="below" tstamp2="0m+2" endid="#d1e1405" staff="1" />
+              <tie tstamp="1.75" startid="#d1e1383" curvedir="above" tstamp2="0m+2" endid="#d1e1428" staff="1" />
             </measure>
-            <sb/>
-            <scoreDef system.leftmar="4.2" system.rightmar="0" spacing.system="30">
-              <staffGrp>
-                <staffGrp symbol="brace">
-                  <staffDef n="2" spacing="13"/>
-                </staffGrp>
-              </staffGrp>
-            </scoreDef>
+            <sb />
             <measure n="6" xml:id="d1e1695" width="77.408">
               <staff n="1">
                 <layer n="1">
-                  <rest xml:id="d1e1709" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e1709" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e1719" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e1741" pname="c" accid="f" oct="5" dur="16" dur.ppq="1"
-                      beam="m1" stem.dir="down">
-                      <accid accid="f"/>
+                    <note xml:id="d1e1719" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e1741" pname="c" accid.ges="f" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down">
+                      <accid accid="f" />
                     </note>
                     <chord xml:id="d335e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
-                      <note xml:id="d1e1765" pname="f" accid="f" oct="4">
-                        <accid accid="f"/>
+                      <note xml:id="d1e1765" pname="f" accid.ges="f" oct="4">
+                        <accid accid="f" />
                       </note>
-                      <note xml:id="d1e1789" pname="f" accid="f" oct="5">
-                        <accid accid="f"/>
+                      <note xml:id="d1e1789" pname="f" accid.ges="f" oct="5">
+                        <accid accid="f" />
                       </note>
                     </chord>
                   </beam>
-                  <rest xml:id="d1e1810" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e1810" dur="16" dur.ppq="1" />
                   <beam>
                     <chord xml:id="d343e1" dur="16" dur.ppq="1" stem.dir="up" beam="i1">
-                      <note xml:id="d1e1820" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e1842" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e1820" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e1842" pname="e" oct="5" accid.ges="f" />
                     </chord>
-                    <rest xml:id="d1e1861" dur="16" dur.ppq="1" beam="m1"/>
+                    <rest xml:id="d1e1861" dur="16" dur.ppq="1" beam="m1" />
                     <chord xml:id="d351e1" dur="16" dur.ppq="1" stem.dir="up" beam="t1">
-                      <note xml:id="d1e1871" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e1894" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e1871" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e1894" pname="e" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -550,21 +554,21 @@
               <staff n="2">
                 <layer n="1">
                   <chord xml:id="d357e1" dur="4" dur.ppq="4" stem.dir="up">
-                    <note xml:id="d1e1916" pname="f" accid="f" oct="2">
-                      <accid accid="f"/>
+                    <note xml:id="d1e1916" pname="f" accid.ges="f" oct="2">
+                      <accid accid="f" />
                     </note>
-                    <note xml:id="d1e1936" pname="f" accid="f" oct="3">
-                      <accid accid="f"/>
+                    <note xml:id="d1e1936" pname="f" accid.ges="f" oct="3">
+                      <accid accid="f" />
                     </note>
                   </chord>
                   <beam>
                     <chord xml:id="d363e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e1957" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e1977" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e1957" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e1977" pname="e" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d369e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e1996" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e2016" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e1996" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e2016" pname="e" oct="3" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -573,170 +577,143 @@
             <measure n="7" xml:id="d1e2036" width="58.29">
               <staff n="1">
                 <layer n="1">
-                  <rest xml:id="d1e2038" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e2038" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e2048" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e2070" pname="c" accid="f" oct="5" dur="16" dur.ppq="1"
-                      beam="m1" stem.dir="down">
-                      <accid accid="f"/>
+                    <note xml:id="d1e2048" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e2070" pname="c" accid.ges="f" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down">
+                      <accid accid="f" />
                     </note>
                     <chord xml:id="d398e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
-                      <note xml:id="d1e2094" pname="f" accid="f" oct="4">
-                        <accid accid="f"/>
+                      <note xml:id="d1e2094" pname="f" accid.ges="f" oct="4">
+                        <accid accid="f" />
                       </note>
-                      <note xml:id="d1e2118" pname="f" accid="f" oct="5">
-                        <accid accid="f"/>
+                      <note xml:id="d1e2118" pname="f" accid.ges="f" oct="5">
+                        <accid accid="f" />
                       </note>
                     </chord>
                   </beam>
-                  <rest xml:id="d1e2139" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e2139" dur="16" dur.ppq="1" />
                   <chord xml:id="d406e1" dur="16" dur.ppq="1" stem.dir="up">
-                    <note xml:id="d1e2149" pname="e" oct="4" accid.ges="f"/>
-                    <note xml:id="d1e2167" pname="e" oct="5" accid.ges="f"/>
+                    <note xml:id="d1e2149" pname="e" oct="4" accid.ges="f" />
+                    <note xml:id="d1e2167" pname="e" oct="5" accid.ges="f" />
                   </chord>
-                  <rest xml:id="d1e2186" dur="8" dur.ppq="2"/>
+                  <rest xml:id="d1e2186" dur="8" dur.ppq="2" />
                 </layer>
               </staff>
               <staff n="2">
                 <layer n="1">
                   <chord xml:id="d414e1" dur="4" dur.ppq="4" stem.dir="up">
-                    <note xml:id="d1e2199" pname="f" accid="f" oct="2">
-                      <accid accid="f"/>
+                    <note xml:id="d1e2199" pname="f" accid.ges="f" oct="2">
+                      <accid accid="f" />
                     </note>
-                    <note xml:id="d1e2220" pname="f" accid="f" oct="3">
-                      <accid accid="f"/>
+                    <note xml:id="d1e2220" pname="f" accid.ges="f" oct="3">
+                      <accid accid="f" />
                     </note>
                   </chord>
                   <chord xml:id="d420e1" dur="8" dur.ppq="2" stem.dir="up">
-                    <note xml:id="d1e2241" pname="e" oct="2" accid.ges="f"/>
-                    <note xml:id="d1e2259" pname="e" oct="3" accid.ges="f"/>
+                    <note xml:id="d1e2241" pname="e" oct="2" accid.ges="f" />
+                    <note xml:id="d1e2259" pname="e" oct="3" accid.ges="f" />
                   </chord>
-                  <rest xml:id="d1e2278" dur="8" dur.ppq="2"/>
+                  <rest xml:id="d1e2278" dur="8" dur.ppq="2" />
                 </layer>
               </staff>
             </measure>
             <measure n="8" xml:id="d1e2288" width="62.568">
               <staff n="1">
                 <layer n="1">
-                  <mRest xml:id="d1e2297" dur="2" dur.ppq="8"/>
-                  <space xml:id="d1e2498" dur="8" dur.ppq="2"/>
+                  <mRest xml:id="d1e2297" dur="2" dur.ppq="8" />
+                  <space xml:id="d1e2498" dur="8" dur.ppq="2" />
                 </layer>
               </staff>
               <staff n="2">
                 <layer n="1">
-                  <rest xml:id="d1e2308" dur="16" dur.ppq="1" ploc="g" oloc="2"/>
+                  <rest xml:id="d1e2308" dur="16" dur.ppq="1" ploc="g" oloc="2" />
                   <beam>
-                    <note xml:id="d1e2322" pname="a" oct="2" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="up" accid.ges="f"/>
-                    <note xml:id="d1e2346" pname="c" accid="f" oct="3" dur="16" dur.ppq="1"
-                      beam="m1" stem.dir="up">
-                      <accid accid="f"/>
+                    <note xml:id="d1e2322" pname="a" oct="2" dur="16" dur.ppq="1" beam="i1" stem.dir="up" accid.ges="f" />
+                    <note xml:id="d1e2346" pname="c" accid.ges="f" oct="3" dur="16" dur.ppq="1" beam="m1" stem.dir="up">
+                      <accid accid="f" />
                     </note>
-                    <note xml:id="d1e2370" pname="a" oct="3" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e2370" pname="a" oct="3" dur="16" dur.ppq="1" beam="t1" stem.dir="up" accid.ges="f" />
                   </beam>
-                  <rest xml:id="d1e2394" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e2394" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e2404" pname="a" oct="3" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="up" accid.ges="f"/>
-                    <note xml:id="d1e2428" pname="c" accid="f" oct="4" dur="16" dur.ppq="1"
-                      beam="m1" stem.dir="up">
-                      <accid accid="f"/>
+                    <note xml:id="d1e2404" pname="a" oct="3" dur="16" dur.ppq="1" beam="i1" stem.dir="up" accid.ges="f" />
+                    <note xml:id="d1e2428" pname="c" accid.ges="f" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="up">
+                      <accid accid="f" />
                     </note>
-                    <note xml:id="d1e2452" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e2452" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1" stem.dir="up" accid.ges="f" />
                   </beam>
                 </layer>
                 <layer n="2">
-                  <note xml:id="d1e2480" pname="a" oct="1" dur="8" dur.ppq="2" stem.dir="down"
-                    accid.ges="f"/>
-                  <note xml:id="d1e2501" pname="a" oct="2" dur="8" dur.ppq="2" stem.dir="down"
-                    accid.ges="f"/>
-                  <rest xml:id="d1e2519" dur="8" dur.ppq="2"/>
+                  <note xml:id="d1e2480" pname="a" oct="1" dur="8" dur.ppq="2" stem.dir="down" accid.ges="f" />
+                  <rest xml:id="d1e2519" dur="8" dur.ppq="2" />
+                  <note xml:id="d1e2501" pname="a" oct="2" dur="8" dur.ppq="2" stem.dir="down" accid.ges="f" />
+                  <rest xml:id="d1e2522" dur="8" dur.ppq="2" />
                 </layer>
               </staff>
               <dynam label="direction" tstamp="1" place="below" staff="1" val="49">p</dynam>
-              <slur tstamp="1.25" startid="#d1e2322" curvedir="below" tstamp2="0m+1.75"
-                endid="#d1e2370" staff="2"/>
-              <slur tstamp="2.25" startid="#d1e2404" curvedir="below" tstamp2="0m+2.75"
-                endid="#d1e2452" staff="2"/>
+              <slur tstamp="1.25" startid="#d1e2322" curvedir="below" tstamp2="0m+1.75" endid="#d1e2370" staff="2" />
+              <slur tstamp="2.25" startid="#d1e2404" curvedir="below" tstamp2="0m+2.75" endid="#d1e2452" staff="2" />
             </measure>
             <measure n="9" xml:id="d1e2529" width="62.112">
               <staff n="1">
                 <layer n="1">
-                  <rest xml:id="d1e2531" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e2531" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e2541" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e2565" pname="c" accid="f" oct="5" dur="16" dur.ppq="1"
-                      beam="m1" stem.dir="down">
-                      <accid accid="f"/>
+                    <note xml:id="d1e2541" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e2565" pname="c" accid.ges="f" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down">
+                      <accid accid="f" />
                     </note>
-                    <note xml:id="d1e2589" pname="a" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e2589" pname="a" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" accid.ges="f" />
                   </beam>
-                  <rest xml:id="d1e2613" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e2613" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e2623" pname="a" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e2647" pname="c" accid="f" oct="6" dur="16" dur.ppq="1"
-                      beam="m1" stem.dir="down">
-                      <accid accid="f"/>
+                    <note xml:id="d1e2623" pname="a" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e2647" pname="c" accid.ges="f" oct="6" dur="16" dur.ppq="1" beam="m1" stem.dir="down">
+                      <accid accid="f" />
                     </note>
-                    <note xml:id="d1e2671" pname="a" oct="6" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e2671" pname="a" oct="6" dur="16" dur.ppq="1" beam="t1" stem.dir="down" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
               <staff n="2">
                 <layer n="1">
-                  <note xml:id="d1e2698" pname="a" oct="3" dur="8" dur.ppq="2" stem.dir="down"
-                    accid.ges="f"/>
-                  <rest xml:id="d1e2716" dur="8" dur.ppq="2"/>
-                  <note xml:id="d1e2727" pname="a" oct="4" dur="8" dur.ppq="2" stem.dir="down"
-                    accid.ges="f"/>
-                  <rest xml:id="d1e2745" dur="8" dur.ppq="2"/>
+                  <note xml:id="d1e2698" pname="a" oct="3" dur="8" dur.ppq="2" stem.dir="down" accid.ges="f" />
+                  <rest xml:id="d1e2716" dur="8" dur.ppq="2" />
+                  <note xml:id="d1e2727" pname="a" oct="4" dur="8" dur.ppq="2" stem.dir="down" accid.ges="f" />
+                  <rest xml:id="d1e2745" dur="8" dur.ppq="2" />
+                  <clef line="2" shape="G" />
                 </layer>
               </staff>
-              <slur tstamp="1.25" startid="#d1e2541" curvedir="above" tstamp2="0m+1.75"
-                endid="#d1e2589" staff="1"/>
-              <slur tstamp="2.25" startid="#d1e2623" curvedir="above" tstamp2="0m+2.75"
-                endid="#d1e2671" staff="1"/>
+              <slur tstamp="1.25" startid="#d1e2541" curvedir="above" tstamp2="0m+1.75" endid="#d1e2589" staff="1" />
+              <slur tstamp="2.25" startid="#d1e2623" curvedir="above" tstamp2="0m+2.75" endid="#d1e2671" staff="1" />
             </measure>
-            <sb/>
-            <scoreDef system.leftmar="4.2" system.rightmar="0" spacing.system="30">
-              <staffGrp>
-                <staffGrp symbol="brace">
-                  <staffDef n="2" clef.line="2" clef.shape="G" spacing="13"/>
-                </staffGrp>
-              </staffGrp>
-            </scoreDef>
+            <sb />
             <measure n="10" xml:id="d1e2755" width="74.336">
               <staff n="1">
                 <layer n="1">
                   <beam>
                     <chord xml:id="d524e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e2782" pname="a" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e2802" pname="a" oct="6" accid.ges="f"/>
+                      <note xml:id="d1e2782" pname="a" oct="5" accid.ges="f" />
+                      <note xml:id="d1e2802" pname="a" oct="6" accid.ges="f" />
                     </chord>
                     <chord xml:id="d530e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e2826" pname="a" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e2846" pname="a" oct="6" accid.ges="f"/>
+                      <note xml:id="d1e2826" pname="a" oct="5" accid.ges="f" />
+                      <note xml:id="d1e2846" pname="a" oct="6" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d536e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e2865" pname="a" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e2885" pname="a" oct="6" accid.ges="f"/>
+                      <note xml:id="d1e2865" pname="a" oct="5" accid.ges="f" />
+                      <note xml:id="d1e2885" pname="a" oct="6" accid.ges="f" />
                     </chord>
                     <chord xml:id="d542e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e2904" pname="a" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e2927" pname="a" oct="6" accid.ges="f"/>
+                      <note xml:id="d1e2904" pname="a" oct="5" accid.ges="f" />
+                      <note xml:id="d1e2927" pname="a" oct="6" accid.ges="f" />
                     </chord>
-                    <chord xml:id="d548e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e2946" pname="a" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e2971" pname="a" oct="6" accid.ges="f"/>
+                    <chord xml:id="d548e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e2946" pname="a" oct="5" accid.ges="f" />
+                      <note xml:id="d1e2971" pname="a" oct="6" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -745,73 +722,66 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d554e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e3001" pname="d" accid="n" oct="4">
-                        <accid accid="n"/>
+                      <note xml:id="d1e3001" pname="d" accid.ges="n" oct="4">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e3021" pname="f" oct="4"/>
-                      <note xml:id="d1e3038" pname="a" accid="n" oct="4">
-                        <accid accid="n"/>
+                      <note xml:id="d1e3021" pname="f" oct="4" />
+                      <note xml:id="d1e3038" pname="a" accid.ges="n" oct="4">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e3057" pname="b" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e3057" pname="b" oct="4" accid.ges="f" />
                     </chord>
                     <chord xml:id="d562e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e3076" pname="d" oct="4" accid.ges="n"/>
-                      <note xml:id="d1e3094" pname="f" oct="4"/>
-                      <note xml:id="d1e3112" pname="a" oct="4" accid.ges="n"/>
-                      <note xml:id="d1e3129" pname="b" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e3076" pname="d" oct="4" accid.ges="n" />
+                      <note xml:id="d1e3094" pname="f" oct="4" />
+                      <note xml:id="d1e3112" pname="a" oct="4" accid.ges="n" />
+                      <note xml:id="d1e3129" pname="b" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d570e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e3148" pname="d" oct="4" accid.ges="n"/>
-                      <note xml:id="d1e3166" pname="f" oct="4"/>
-                      <note xml:id="d1e3183" pname="a" oct="4" accid.ges="n"/>
-                      <note xml:id="d1e3200" pname="b" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e3148" pname="d" oct="4" accid.ges="n" />
+                      <note xml:id="d1e3166" pname="f" oct="4" />
+                      <note xml:id="d1e3183" pname="a" oct="4" accid.ges="n" />
+                      <note xml:id="d1e3200" pname="b" oct="4" accid.ges="f" />
                     </chord>
                     <chord xml:id="d578e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e3219" pname="d" oct="4" accid.ges="n"/>
-                      <note xml:id="d1e3237" pname="f" oct="4"/>
-                      <note xml:id="d1e3254" pname="a" oct="4" accid.ges="n"/>
-                      <note xml:id="d1e3271" pname="b" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e3219" pname="d" oct="4" accid.ges="n" />
+                      <note xml:id="d1e3237" pname="f" oct="4" />
+                      <note xml:id="d1e3254" pname="a" oct="4" accid.ges="n" />
+                      <note xml:id="d1e3271" pname="b" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
               <dynam label="direction" tstamp="1" place="below" staff="1" val="80">mf</dynam>
-              <hairpin tstamp="1.5" place="below" staff="1" form="cres" tstamp2="0m+3"
-                endid="#d1e2971"/>
-              <tie tstamp="2.75" startid="#d1e2946" curvedir="above" tstamp2="1m+1" endid="#d1e3292"
-                staff="1"/>
-              <tie tstamp="2.75" startid="#d1e2971" curvedir="above" tstamp2="1m+1" endid="#d1e3317"
-                staff="1"/>
+              <hairpin tstamp="1.5" place="below" staff="1" form="cres" tstamp2="0m+3" endid="#d1e2971" />
+              <tie tstamp="2.75" startid="#d1e2946" curvedir="below" tstamp2="1m+1" endid="#d1e3292" staff="1" />
+              <tie tstamp="2.75" startid="#d1e2971" curvedir="above" tstamp2="1m+1" endid="#d1e3317" staff="1" />
             </measure>
             <measure n="11" xml:id="d1e3290" width="64.664">
               <staff n="1">
                 <layer n="1">
                   <beam>
-                    <chord xml:id="d622e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e3292" pname="a" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e3317" pname="a" oct="6" accid.ges="f"/>
+                    <chord xml:id="d622e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
+                      <note xml:id="d1e3292" pname="a" oct="5" accid.ges="f" />
+                      <note xml:id="d1e3317" pname="a" oct="6" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e3339" pname="e" oct="6" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e3361" pname="f" oct="6" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down"/>
-                    <note xml:id="d1e3381" pname="c" oct="6" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e3339" pname="e" oct="6" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e3361" pname="f" oct="6" dur="16" dur.ppq="1" beam="m1" stem.dir="down" />
+                    <note xml:id="d1e3381" pname="c" oct="6" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e3401" pname="e" oct="6" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e3401" pname="e" oct="6" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d632e1" dur="8" dur.ppq="2" stem.dir="down" beam="m1">
-                      <note xml:id="d1e3423" pname="a" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e3443" pname="f" oct="6"/>
+                      <note xml:id="d1e3423" pname="a" oct="5" accid.ges="f" />
+                      <note xml:id="d1e3443" pname="f" oct="6" />
                     </chord>
-                    <chord xml:id="d638e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e3460" pname="f" accid="f" oct="5">
-                        <accid accid="f"/>
+                    <chord xml:id="d638e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e3460" pname="f" accid.ges="f" oct="5">
+                        <accid accid="f" />
                       </note>
-                      <note xml:id="d1e3487" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e3487" pname="a" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -820,67 +790,61 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d644e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e3513" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e3533" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e3552" pname="c" oct="5"/>
+                      <note xml:id="d1e3513" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e3533" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e3552" pname="c" oct="5" />
                     </chord>
                     <chord xml:id="d651e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e3569" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e3589" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e3608" pname="c" oct="5"/>
+                      <note xml:id="d1e3569" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e3589" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e3608" pname="c" oct="5" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d658e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e3625" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e3645" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e3664" pname="c" oct="5"/>
+                      <note xml:id="d1e3625" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e3645" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e3664" pname="c" oct="5" />
                     </chord>
                     <chord xml:id="d665e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e3681" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e3701" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e3721" pname="c" oct="5"/>
+                      <note xml:id="d1e3681" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e3701" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e3721" pname="c" oct="5" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="2.75" startid="#d1e3460" curvedir="above" tstamp2="1m+1" endid="#d1e3740"
-                staff="1"/>
-              <tie tstamp="2.75" startid="#d1e3487" curvedir="above" tstamp2="1m+1" endid="#d1e3765"
-                staff="1"/>
+              <tie tstamp="2.75" startid="#d1e3460" curvedir="below" tstamp2="1m+1" endid="#d1e3740" staff="1" />
+              <tie tstamp="2.75" startid="#d1e3487" curvedir="above" tstamp2="1m+1" endid="#d1e3765" staff="1" />
             </measure>
             <measure n="12" xml:id="d1e3738" width="65.708">
               <staff n="1">
                 <layer n="1">
                   <beam>
-                    <chord xml:id="d703e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e3740" pname="f" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e3765" pname="a" oct="5" accid.ges="f"/>
+                    <chord xml:id="d703e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
+                      <note xml:id="d1e3740" pname="f" oct="5" accid.ges="f" />
+                      <note xml:id="d1e3765" pname="a" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e3787" pname="b" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e3787" pname="b" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d710e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e3809" pname="f" accid="f" oct="5">
-                        <accid accid="f"/>
+                      <note xml:id="d1e3809" pname="f" accid.ges="f" oct="5">
+                        <accid accid="f" />
                       </note>
-                      <note xml:id="d1e3833" pname="c" accid="f" oct="6">
-                        <accid accid="f"/>
+                      <note xml:id="d1e3833" pname="c" accid.ges="f" oct="6">
+                        <accid accid="f" />
                       </note>
                     </chord>
-                    <note xml:id="d1e3854" pname="a" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e3854" pname="a" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e3876" pname="b" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e3876" pname="b" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d718e1" dur="8" dur.ppq="2" stem.dir="down" beam="m1">
-                      <note xml:id="d1e3898" pname="e" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e3918" pname="c" accid="n" oct="6">
-                        <accid accid="n"/>
+                      <note xml:id="d1e3898" pname="e" oct="5" accid.ges="f" />
+                      <note xml:id="d1e3918" pname="c" accid.ges="n" oct="6">
+                        <accid accid="n" />
                       </note>
                     </chord>
-                    <note xml:id="d1e3937" pname="a" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e3937" pname="a" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
@@ -888,32 +852,32 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d725e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e3963" pname="f" accid="f" oct="4">
-                        <accid accid="f"/>
+                      <note xml:id="d1e3963" pname="f" accid.ges="f" oct="4">
+                        <accid accid="f" />
                       </note>
-                      <note xml:id="d1e3985" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e4004" pname="c" accid="f" oct="5">
-                        <accid accid="f"/>
+                      <note xml:id="d1e3985" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e4004" pname="c" accid.ges="f" oct="5">
+                        <accid accid="f" />
                       </note>
                     </chord>
                     <chord xml:id="d732e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e4025" pname="f" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e4045" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e4064" pname="c" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e4025" pname="f" oct="4" accid.ges="f" />
+                      <note xml:id="d1e4045" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e4064" pname="c" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d739e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e4083" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e4103" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e4122" pname="c" accid="n" oct="5">
-                        <accid accid="n"/>
+                      <note xml:id="d1e4083" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e4103" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e4122" pname="c" accid.ges="n" oct="5">
+                        <accid accid="n" />
                       </note>
                     </chord>
                     <chord xml:id="d746e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e4141" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e4161" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e4181" pname="c" oct="5" accid.ges="n"/>
+                      <note xml:id="d1e4141" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e4161" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e4181" pname="c" oct="5" accid.ges="n" />
                     </chord>
                   </beam>
                 </layer>
@@ -924,25 +888,24 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d776e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
-                      <note xml:id="d1e4200" pname="e" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e4222" pname="c" oct="6"/>
+                      <note xml:id="d1e4200" pname="e" oct="5" accid.ges="f" />
+                      <note xml:id="d1e4222" pname="c" oct="6" />
                     </chord>
-                    <note xml:id="d1e4239" pname="a" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e4239" pname="a" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d783e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e4261" pname="e" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e4281" pname="b" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e4261" pname="e" oct="5" accid.ges="f" />
+                      <note xml:id="d1e4281" pname="b" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d789e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e4300" pname="e" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e4320" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e4300" pname="e" oct="5" accid.ges="f" />
+                      <note xml:id="d1e4320" pname="a" oct="5" accid.ges="f" />
                     </chord>
-                    <rest xml:id="d1e4339" dur="16" dur.ppq="1" beam="m1"/>
-                    <chord xml:id="d797e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e4349" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e4374" pname="a" oct="5" accid.ges="f"/>
+                    <rest xml:id="d1e4339" dur="16" dur.ppq="1" beam="m1" />
+                    <chord xml:id="d797e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e4349" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e4374" pname="a" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -951,61 +914,53 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d803e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e4400" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e4420" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e4439" pname="c" oct="5"/>
+                      <note xml:id="d1e4400" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e4420" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e4439" pname="c" oct="5" />
                     </chord>
                     <chord xml:id="d810e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e4456" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e4476" pname="g" oct="4"/>
-                      <note xml:id="d1e4493" pname="d" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e4456" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e4476" pname="g" oct="4" />
+                      <note xml:id="d1e4493" pname="d" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                   <chord xml:id="d817e1" dur="8" dur.ppq="2" stem.dir="down">
-                    <note xml:id="d1e4512" pname="a" oct="4" accid.ges="f"/>
-                    <note xml:id="d1e4530" pname="c" oct="5"/>
+                    <note xml:id="d1e4512" pname="a" oct="4" accid.ges="f" />
+                    <note xml:id="d1e4530" pname="c" oct="5" />
                   </chord>
-                  <rest xml:id="d1e4547" dur="8" dur.ppq="2"/>
+                  <rest xml:id="d1e4547" dur="8" dur.ppq="2" />
+                  <clef line="4" shape="F" />
                 </layer>
               </staff>
-              <tie tstamp="2.75" startid="#d1e4349" curvedir="above" tstamp2="1m+1" endid="#d1e4571"
-                staff="1"/>
-              <tie tstamp="2.75" startid="#d1e4374" curvedir="above" tstamp2="1m+1" endid="#d1e4594"
-                staff="1"/>
+              <tie tstamp="2.75" startid="#d1e4349" curvedir="below" tstamp2="1m+1" endid="#d1e4571" staff="1" />
+              <tie tstamp="2.75" startid="#d1e4374" curvedir="above" tstamp2="1m+1" endid="#d1e4594" staff="1" />
             </measure>
-            <sb/>
-            <scoreDef system.leftmar="4.2" system.rightmar="0" spacing.system="30">
-              <staffGrp>
-                <staffGrp symbol="brace">
-                  <staffDef n="2" spacing="13"/>
-                </staffGrp>
-              </staffGrp>
-            </scoreDef>
+            <sb />
             <measure n="14" xml:id="d1e4557" width="79.652">
               <staff n="1">
                 <layer n="1">
                   <beam>
-                    <chord xml:id="d854e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e4571" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e4594" pname="a" oct="5" accid.ges="f"/>
+                    <chord xml:id="d854e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
+                      <note xml:id="d1e4571" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e4594" pname="a" oct="5" accid.ges="f" />
                     </chord>
                     <chord xml:id="d860e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e4616" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e4636" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e4616" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e4636" pname="a" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d866e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e4655" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e4675" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e4655" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e4675" pname="a" oct="5" accid.ges="f" />
                     </chord>
                     <chord xml:id="d872e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e4694" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e4716" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e4694" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e4716" pname="a" oct="5" accid.ges="f" />
                     </chord>
-                    <chord xml:id="d878e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e4735" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e4760" pname="a" oct="5" accid.ges="f"/>
+                    <chord xml:id="d878e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e4735" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e4760" pname="a" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -1014,72 +969,67 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d884e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e4786" pname="d" accid="n" oct="3">
-                        <accid accid="n"/>
+                      <note xml:id="d1e4786" pname="d" accid.ges="n" oct="3">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e4806" pname="f" oct="3"/>
-                      <note xml:id="d1e4823" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e4842" pname="b" accid="n" oct="3">
-                        <accid accid="n"/>
+                      <note xml:id="d1e4806" pname="f" oct="3" />
+                      <note xml:id="d1e4823" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e4842" pname="b" accid.ges="n" oct="3">
+                        <accid accid="n" />
                       </note>
                     </chord>
                     <chord xml:id="d892e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e4861" pname="d" oct="3" accid.ges="n"/>
-                      <note xml:id="d1e4879" pname="f" oct="3"/>
-                      <note xml:id="d1e4896" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e4915" pname="b" oct="3" accid.ges="n"/>
+                      <note xml:id="d1e4861" pname="d" oct="3" accid.ges="n" />
+                      <note xml:id="d1e4879" pname="f" oct="3" />
+                      <note xml:id="d1e4896" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e4915" pname="b" oct="3" accid.ges="n" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d900e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e4932" pname="d" oct="3" accid.ges="n"/>
-                      <note xml:id="d1e4950" pname="f" oct="3"/>
-                      <note xml:id="d1e4968" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e4987" pname="b" oct="3" accid.ges="n"/>
+                      <note xml:id="d1e4932" pname="d" oct="3" accid.ges="n" />
+                      <note xml:id="d1e4950" pname="f" oct="3" />
+                      <note xml:id="d1e4968" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e4987" pname="b" oct="3" accid.ges="n" />
                     </chord>
                     <chord xml:id="d908e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e5004" pname="d" oct="3" accid.ges="n"/>
-                      <note xml:id="d1e5022" pname="f" oct="3"/>
-                      <note xml:id="d1e5039" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e5058" pname="b" oct="3" accid.ges="n"/>
+                      <note xml:id="d1e5004" pname="d" oct="3" accid.ges="n" />
+                      <note xml:id="d1e5022" pname="f" oct="3" />
+                      <note xml:id="d1e5039" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e5058" pname="b" oct="3" accid.ges="n" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="2.75" startid="#d1e4735" curvedir="above" tstamp2="1m+1" endid="#d1e5077"
-                staff="1"/>
-              <tie tstamp="2.75" startid="#d1e4760" curvedir="above" tstamp2="1m+1" endid="#d1e5102"
-                staff="1"/>
+              <tie tstamp="2.75" startid="#d1e4735" curvedir="below" tstamp2="1m+1" endid="#d1e5077" staff="1" />
+              <tie tstamp="2.75" startid="#d1e4760" curvedir="above" tstamp2="1m+1" endid="#d1e5102" staff="1" />
             </measure>
             <measure n="15" xml:id="d1e5075" width="59.506">
               <staff n="1">
                 <layer n="1">
                   <beam>
-                    <chord xml:id="d947e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e5077" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e5102" pname="a" oct="5" accid.ges="f"/>
+                    <chord xml:id="d947e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
+                      <note xml:id="d1e5077" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e5102" pname="a" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e5124" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e5124" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d954e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e5146" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e5168" pname="f" oct="5"/>
+                      <note xml:id="d1e5146" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e5168" pname="f" oct="5" />
                     </chord>
-                    <note xml:id="d1e5185" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e5185" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e5205" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e5205" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d962e1" dur="8" dur.ppq="2" stem.dir="down" beam="m1">
-                      <note xml:id="d1e5227" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e5247" pname="f" oct="5"/>
+                      <note xml:id="d1e5227" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e5247" pname="f" oct="5" />
                     </chord>
-                    <chord xml:id="d968e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e5264" pname="f" accid="f" oct="4">
-                        <accid accid="f"/>
+                    <chord xml:id="d968e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e5264" pname="f" accid.ges="f" oct="4">
+                        <accid accid="f" />
                       </note>
-                      <note xml:id="d1e5291" pname="a" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e5291" pname="a" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -1088,67 +1038,61 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d974e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e5317" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e5337" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e5356" pname="c" oct="4"/>
+                      <note xml:id="d1e5317" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e5337" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e5356" pname="c" oct="4" />
                     </chord>
                     <chord xml:id="d981e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e5373" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e5393" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e5412" pname="c" oct="4"/>
+                      <note xml:id="d1e5373" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e5393" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e5412" pname="c" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d988e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e5429" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e5449" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e5468" pname="c" oct="4"/>
+                      <note xml:id="d1e5429" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e5449" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e5468" pname="c" oct="4" />
                     </chord>
                     <chord xml:id="d995e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e5485" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e5506" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e5525" pname="c" oct="4"/>
+                      <note xml:id="d1e5485" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e5506" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e5525" pname="c" oct="4" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="2.75" startid="#d1e5264" curvedir="above" tstamp2="1m+1" endid="#d1e5544"
-                staff="1"/>
-              <tie tstamp="2.75" startid="#d1e5291" curvedir="above" tstamp2="1m+1" endid="#d1e5569"
-                staff="1"/>
+              <tie tstamp="2.75" startid="#d1e5264" curvedir="below" tstamp2="1m+1" endid="#d1e5544" staff="1" />
+              <tie tstamp="2.75" startid="#d1e5291" curvedir="above" tstamp2="1m+1" endid="#d1e5569" staff="1" />
             </measure>
             <measure n="16" xml:id="d1e5542" width="63.406">
               <staff n="1">
                 <layer n="1">
                   <beam>
-                    <chord xml:id="d1033e1" dur="16" dur.ppq="1" stem.dir="up" beam="i1" tie="t">
-                      <note xml:id="d1e5544" pname="f" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e5569" pname="a" oct="4" accid.ges="f"/>
+                    <chord xml:id="d1033e1" dur="16" dur.ppq="1" stem.dir="up" beam="i1">
+                      <note xml:id="d1e5544" pname="f" oct="4" accid.ges="f" />
+                      <note xml:id="d1e5569" pname="a" oct="4" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e5591" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e5591" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="up" accid.ges="f" />
                     <chord xml:id="d1040e1" dur="16" dur.ppq="1" stem.dir="up" beam="m1">
-                      <note xml:id="d1e5613" pname="f" accid="f" oct="4">
-                        <accid accid="f"/>
+                      <note xml:id="d1e5613" pname="f" accid.ges="f" oct="4">
+                        <accid accid="f" />
                       </note>
-                      <note xml:id="d1e5637" pname="c" accid="f" oct="5">
-                        <accid accid="f"/>
+                      <note xml:id="d1e5637" pname="c" accid.ges="f" oct="5">
+                        <accid accid="f" />
                       </note>
                     </chord>
-                    <note xml:id="d1e5658" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e5658" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1" stem.dir="up" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e5680" pname="b" oct="4" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e5680" pname="b" oct="4" dur="16" dur.ppq="1" beam="i1" stem.dir="up" accid.ges="f" />
                     <chord xml:id="d1048e1" dur="8" dur.ppq="2" stem.dir="up" beam="m1">
-                      <note xml:id="d1e5702" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e5722" pname="c" accid="n" oct="5">
-                        <accid accid="n"/>
+                      <note xml:id="d1e5702" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e5722" pname="c" accid.ges="n" oct="5">
+                        <accid accid="n" />
                       </note>
                     </chord>
-                    <note xml:id="d1e5741" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e5741" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1" stem.dir="up" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
@@ -1156,32 +1100,32 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d1055e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e5767" pname="f" accid="f" oct="3">
-                        <accid accid="f"/>
+                      <note xml:id="d1e5767" pname="f" accid.ges="f" oct="3">
+                        <accid accid="f" />
                       </note>
-                      <note xml:id="d1e5789" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e5808" pname="c" accid="f" oct="4">
-                        <accid accid="f"/>
+                      <note xml:id="d1e5789" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e5808" pname="c" accid.ges="f" oct="4">
+                        <accid accid="f" />
                       </note>
                     </chord>
                     <chord xml:id="d1062e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e5829" pname="f" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e5849" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e5868" pname="c" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e5829" pname="f" oct="3" accid.ges="f" />
+                      <note xml:id="d1e5849" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e5868" pname="c" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d1069e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e5887" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e5907" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e5926" pname="c" accid="n" oct="4">
-                        <accid accid="n"/>
+                      <note xml:id="d1e5887" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e5907" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e5926" pname="c" accid.ges="n" oct="4">
+                        <accid accid="n" />
                       </note>
                     </chord>
                     <chord xml:id="d1076e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e5945" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e5965" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e5985" pname="c" oct="4" accid.ges="n"/>
+                      <note xml:id="d1e5945" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e5965" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e5985" pname="c" oct="4" accid.ges="n" />
                     </chord>
                   </beam>
                 </layer>
@@ -1194,45 +1138,44 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d1106e1" dur="16" dur.ppq="1" stem.dir="up" beam="i1">
-                      <note xml:id="d1e6006" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e6028" pname="c" oct="5"/>
+                      <note xml:id="d1e6006" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e6028" pname="c" oct="5" />
                     </chord>
-                    <note xml:id="d1e6045" pname="a" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e6045" pname="a" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="up" accid.ges="f" />
                     <chord xml:id="d1113e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e6067" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e6087" pname="b" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e6067" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e6087" pname="b" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <chord xml:id="d1119e1" dur="8" dur.ppq="2" stem.dir="up">
-                    <note xml:id="d1e6106" pname="e" oct="4" accid.ges="f"/>
-                    <note xml:id="d1e6124" pname="a" oct="4" accid.ges="f"/>
+                    <note xml:id="d1e6106" pname="e" oct="4" accid.ges="f" />
+                    <note xml:id="d1e6124" pname="a" oct="4" accid.ges="f" />
                   </chord>
-                  <rest xml:id="d1e6143" dur="8" dur.ppq="2"/>
+                  <rest xml:id="d1e6143" dur="8" dur.ppq="2" />
                 </layer>
               </staff>
               <staff n="2">
                 <layer n="1">
                   <beam>
                     <chord xml:id="d1127e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e6156" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e6177" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e6196" pname="c" oct="4"/>
+                      <note xml:id="d1e6156" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e6177" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e6196" pname="c" oct="4" />
                     </chord>
                     <chord xml:id="d1134e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e6213" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e6233" pname="g" oct="3"/>
-                      <note xml:id="d1e6250" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e6213" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e6233" pname="g" oct="3" />
+                      <note xml:id="d1e6250" pname="d" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d1141e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e6269" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e6289" pname="c" oct="4"/>
+                      <note xml:id="d1e6269" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e6289" pname="c" oct="4" />
                     </chord>
                     <chord xml:id="d1147e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e6306" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e6326" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e6306" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e6326" pname="e" oct="3" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -1240,61 +1183,53 @@
             </measure>
           </ending>
           <ending n="2">
-            <sb/>
-            <scoreDef system.leftmar="4.2" system.rightmar="0" spacing.system="30">
-              <staffGrp>
-                <staffGrp symbol="brace">
-                  <staffDef n="2" spacing="13"/>
-                </staffGrp>
-              </staffGrp>
-            </scoreDef>
-            <measure n="18" xml:id="d1e6351" right="rptstart" width="74.752">
+            <sb />
+            <measure n="18" xml:id="d1e6351" right="dbl" width="74.752">
               <staff n="1">
                 <layer n="1">
                   <beam>
                     <chord xml:id="d1174e1" dur="16" dur.ppq="1" stem.dir="up" beam="i1">
-                      <note xml:id="d1e6367" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e6389" pname="c" oct="5"/>
+                      <note xml:id="d1e6367" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e6389" pname="c" oct="5" />
                     </chord>
-                    <note xml:id="d1e6406" pname="a" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e6406" pname="a" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="up" accid.ges="f" />
                     <chord xml:id="d1181e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e6428" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e6448" pname="b" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e6428" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e6448" pname="b" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <chord xml:id="d1187e1" dur="8" dur.ppq="2" stem.dir="up">
-                    <note xml:id="d1e6467" pname="e" oct="4" accid.ges="f"/>
-                    <note xml:id="d1e6485" pname="a" oct="4" accid.ges="f"/>
+                    <note xml:id="d1e6467" pname="e" oct="4" accid.ges="f" />
+                    <note xml:id="d1e6485" pname="a" oct="4" accid.ges="f" />
                   </chord>
-                  <rest xml:id="d1e6504" dur="8" dur.ppq="2"/>
+                  <rest xml:id="d1e6504" dur="8" dur.ppq="2" />
                 </layer>
               </staff>
               <staff n="2">
                 <layer n="1">
                   <beam>
                     <chord xml:id="d1195e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e6518" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e6538" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e6557" pname="c" oct="4"/>
+                      <note xml:id="d1e6518" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e6538" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e6557" pname="c" oct="4" />
                     </chord>
                     <chord xml:id="d1202e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e6574" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e6594" pname="g" oct="3"/>
-                      <note xml:id="d1e6611" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e6574" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e6594" pname="g" oct="3" />
+                      <note xml:id="d1e6611" pname="d" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d1209e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e6630" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e6650" pname="c" oct="4"/>
+                      <note xml:id="d1e6630" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e6650" pname="c" oct="4" />
                     </chord>
                     <chord xml:id="d1215e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e6667" pname="a" accid="n" oct="2">
-                        <accid accid="n"/>
+                      <note xml:id="d1e6667" pname="a" accid.ges="n" oct="2">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e6687" pname="a" accid="n" oct="3">
-                        <accid accid="n"/>
+                      <note xml:id="d1e6687" pname="a" accid.ges="n" oct="3">
+                        <accid accid="n" />
                       </note>
                     </chord>
                   </beam>
@@ -1306,30 +1241,26 @@
             <measure n="19" xml:id="d1e6708" left="rptstart" width="61.242">
               <staff n="1">
                 <layer n="1">
-                  <rest xml:id="d1e6721" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e6721" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e6731" pname="g" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e6731" pname="g" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" />
                     <chord xml:id="d1243e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e6751" pname="e" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e6773" pname="e" oct="6" accid.ges="f"/>
+                      <note xml:id="d1e6751" pname="e" oct="5" accid.ges="f" />
+                      <note xml:id="d1e6773" pname="e" oct="6" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e6792" pname="g" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e6792" pname="g" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e6812" pname="b" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e6812" pname="b" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d1251e1" dur="8" dur.ppq="2" stem.dir="down" beam="m1">
-                      <note xml:id="d1e6834" pname="d" accid="n" oct="5">
-                        <accid accid="n"/>
+                      <note xml:id="d1e6834" pname="d" accid.ges="n" oct="5">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e6854" pname="d" accid="n" oct="6">
-                        <accid accid="n"/>
+                      <note xml:id="d1e6854" pname="d" accid.ges="n" oct="6">
+                        <accid accid="n" />
                       </note>
                     </chord>
-                    <note xml:id="d1e6873" pname="g" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e6873" pname="g" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                 </layer>
               </staff>
@@ -1337,31 +1268,31 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d1258e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e6903" pname="b" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e6923" pname="b" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e6903" pname="b" oct="2" accid.ges="f" />
+                      <note xml:id="d1e6923" pname="b" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d1264e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e6942" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e6962" pname="g" oct="3"/>
-                      <note xml:id="d1e6979" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e6942" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e6962" pname="g" oct="3" />
+                      <note xml:id="d1e6979" pname="d" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d1271e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e6998" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e7018" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e6998" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e7018" pname="e" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d1277e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e7037" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e7057" pname="g" oct="3"/>
-                      <note xml:id="d1e7075" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e7037" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e7057" pname="g" oct="3" />
+                      <note xml:id="d1e7075" pname="d" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
               <dynam label="direction" tstamp="1" place="below" staff="1" val="96">f</dynam>
               <dir tstamp="1" place="above" staff="2" label="words">
-                <rend fontfam="Times New Roman" fontstyle="italic">staccato</rend>
+                <rend fontfam="Times New Roman" fontstyle="italic">stacc.</rend>
               </dir>
             </measure>
             <measure n="20" xml:id="d1e7094" width="65.832">
@@ -1369,31 +1300,27 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d1313e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
-                      <note xml:id="d1e7096" pname="d" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e7118" pname="d" oct="6" accid.ges="f"/>
+                      <note xml:id="d1e7096" pname="d" oct="5" accid.ges="f" />
+                      <note xml:id="d1e7118" pname="d" oct="6" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e7137" pname="g" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down"/>
-                    <note xml:id="d1e7157" pname="b" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <chord xml:id="d1321e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e7179" pname="c" oct="5"/>
-                      <note xml:id="d1e7202" pname="c" oct="6"/>
+                    <note xml:id="d1e7137" pname="g" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" />
+                    <note xml:id="d1e7157" pname="b" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <chord xml:id="d1321e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e7179" pname="c" oct="5" />
+                      <note xml:id="d1e7202" pname="c" oct="6" />
                     </chord>
                   </beam>
                   <beam>
-                    <chord xml:id="d1327e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e7222" pname="c" oct="5"/>
-                      <note xml:id="d1e7245" pname="c" oct="6"/>
+                    <chord xml:id="d1327e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
+                      <note xml:id="d1e7222" pname="c" oct="5" />
+                      <note xml:id="d1e7245" pname="c" oct="6" />
                     </chord>
-                    <note xml:id="d1e7265" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e7265" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d1334e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e7287" pname="b" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e7309" pname="b" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e7287" pname="b" oct="4" accid.ges="f" />
+                      <note xml:id="d1e7309" pname="b" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e7329" pname="e" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e7329" pname="e" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
@@ -1401,55 +1328,49 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d1341e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e7354" pname="b" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e7374" pname="b" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e7354" pname="b" oct="2" accid.ges="f" />
+                      <note xml:id="d1e7374" pname="b" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d1347e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e7393" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e7413" pname="g" oct="3"/>
-                      <note xml:id="d1e7430" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e7393" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e7413" pname="g" oct="3" />
+                      <note xml:id="d1e7430" pname="d" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d1354e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e7449" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e7469" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e7449" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e7469" pname="e" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d1360e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e7488" pname="g" oct="2"/>
-                      <note xml:id="d1e7506" pname="g" oct="3"/>
+                      <note xml:id="d1e7488" pname="g" oct="2" />
+                      <note xml:id="d1e7506" pname="g" oct="3" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="1.75" startid="#d1e7179" curvedir="above" tstamp2="0m+2" endid="#d1e7222"
-                staff="1"/>
-              <tie tstamp="1.75" startid="#d1e7202" curvedir="above" tstamp2="0m+2" endid="#d1e7245"
-                staff="1"/>
+              <tie tstamp="1.75" startid="#d1e7179" curvedir="below" tstamp2="0m+2" endid="#d1e7222" staff="1" />
+              <tie tstamp="1.75" startid="#d1e7202" curvedir="above" tstamp2="0m+2" endid="#d1e7245" staff="1" />
             </measure>
             <measure n="21" xml:id="d1e7523" width="58.554">
               <staff n="1">
                 <layer n="1">
-                  <rest xml:id="d1e7525" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e7525" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e7535" pname="c" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e7535" pname="c" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" />
                     <chord xml:id="d1400e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e7555" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e7577" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e7555" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e7577" pname="a" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e7596" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e7596" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e7616" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e7616" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d1408e1" dur="8" dur.ppq="2" stem.dir="down" beam="m1">
-                      <note xml:id="d1e7638" pname="f" oct="4"/>
-                      <note xml:id="d1e7656" pname="f" oct="5"/>
+                      <note xml:id="d1e7638" pname="f" oct="4" />
+                      <note xml:id="d1e7656" pname="f" oct="5" />
                     </chord>
-                    <note xml:id="d1e7673" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e7673" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                 </layer>
               </staff>
@@ -1457,64 +1378,54 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d1415e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e7696" pname="a" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e7717" pname="a" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e7696" pname="a" oct="2" accid.ges="f" />
+                      <note xml:id="d1e7717" pname="a" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d1421e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e7736" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e7756" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e7775" pname="c" oct="4"/>
+                      <note xml:id="d1e7736" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e7756" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e7775" pname="c" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d1428e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e7792" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e7812" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e7792" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e7812" pname="e" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d1434e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e7831" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e7851" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e7870" pname="c" oct="4"/>
+                      <note xml:id="d1e7831" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e7851" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e7870" pname="c" oct="4" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
             </measure>
-            <pb/>
-            <scoreDef system.leftmar="4.2" system.rightmar="0" system.topmar="14">
-              <staffGrp>
-                <staffGrp symbol="brace">
-                  <staffDef n="2" spacing="13"/>
-                </staffGrp>
-              </staffGrp>
-            </scoreDef>
+            <pb />
             <measure n="22" xml:id="d1e7887" width="77.536">
               <staff n="1">
                 <layer n="1">
                   <beam>
                     <chord xml:id="d1466e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
-                      <note xml:id="d1e7901" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e7923" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e7901" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e7923" pname="a" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e7942" pname="c" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down"/>
-                    <note xml:id="d1e7962" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <chord xml:id="d1474e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e7984" pname="f" oct="4"/>
-                      <note xml:id="d1e8007" pname="f" oct="5"/>
+                    <note xml:id="d1e7942" pname="c" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" />
+                    <note xml:id="d1e7962" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <chord xml:id="d1474e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e7984" pname="f" oct="4" />
+                      <note xml:id="d1e8007" pname="f" oct="5" />
                     </chord>
                   </beam>
                   <beam>
-                    <chord xml:id="d1480e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e8027" pname="f" oct="4"/>
-                      <note xml:id="d1e8050" pname="f" oct="5"/>
+                    <chord xml:id="d1480e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
+                      <note xml:id="d1e8027" pname="f" oct="4" />
+                      <note xml:id="d1e8050" pname="f" oct="5" />
                     </chord>
-                    <note xml:id="d1e8070" pname="c" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e8070" pname="c" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" />
                     <chord xml:id="d1487e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e8090" pname="f" oct="4"/>
-                      <note xml:id="d1e8109" pname="f" oct="5"/>
+                      <note xml:id="d1e8090" pname="f" oct="4" />
+                      <note xml:id="d1e8109" pname="f" oct="5" />
                     </chord>
                   </beam>
                 </layer>
@@ -1523,59 +1434,53 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d1493e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e8129" pname="a" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e8149" pname="a" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e8129" pname="a" oct="2" accid.ges="f" />
+                      <note xml:id="d1e8149" pname="a" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d1499e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e8168" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e8188" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e8207" pname="c" oct="4"/>
+                      <note xml:id="d1e8168" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e8188" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e8207" pname="c" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d1506e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e8224" pname="a" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e8244" pname="a" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e8224" pname="a" oct="2" accid.ges="f" />
+                      <note xml:id="d1e8244" pname="a" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d1512e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e8263" pname="a" accid="n" oct="2">
-                        <accid accid="n"/>
+                      <note xml:id="d1e8263" pname="a" accid.ges="n" oct="2">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e8283" pname="a" accid="n" oct="3">
-                        <accid accid="n"/>
+                      <note xml:id="d1e8283" pname="a" accid.ges="n" oct="3">
+                        <accid accid="n" />
                       </note>
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="1.75" startid="#d1e7984" curvedir="above" tstamp2="0m+2" endid="#d1e8027"
-                staff="1"/>
-              <tie tstamp="1.75" startid="#d1e8007" curvedir="above" tstamp2="0m+2" endid="#d1e8050"
-                staff="1"/>
+              <tie tstamp="1.75" startid="#d1e7984" curvedir="below" tstamp2="0m+2" endid="#d1e8027" staff="1" />
+              <tie tstamp="1.75" startid="#d1e8007" curvedir="above" tstamp2="0m+2" endid="#d1e8050" staff="1" />
             </measure>
             <measure n="23" xml:id="d1e8302" width="59.994">
               <staff n="1">
                 <layer n="1">
-                  <rest xml:id="d1e8304" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e8304" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e8314" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e8314" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d1552e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e8336" pname="g" oct="4"/>
-                      <note xml:id="d1e8356" pname="g" oct="5"/>
+                      <note xml:id="d1e8336" pname="g" oct="4" />
+                      <note xml:id="d1e8356" pname="g" oct="5" />
                     </chord>
-                    <note xml:id="d1e8373" pname="b" oct="4" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e8373" pname="b" oct="4" dur="16" dur.ppq="1" beam="t1" stem.dir="down" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e8395" pname="d" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e8395" pname="d" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d1560e1" dur="8" dur.ppq="2" stem.dir="down" beam="m1">
-                      <note xml:id="d1e8417" pname="f" oct="4"/>
-                      <note xml:id="d1e8435" pname="f" oct="5"/>
+                      <note xml:id="d1e8417" pname="f" oct="4" />
+                      <note xml:id="d1e8435" pname="f" oct="5" />
                     </chord>
-                    <note xml:id="d1e8452" pname="e" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e8452" pname="e" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
@@ -1583,24 +1488,24 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d1567e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e8477" pname="b" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e8498" pname="b" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e8477" pname="b" oct="2" accid.ges="f" />
+                      <note xml:id="d1e8498" pname="b" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d1573e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e8517" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e8537" pname="g" oct="3"/>
-                      <note xml:id="d1e8554" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e8517" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e8537" pname="g" oct="3" />
+                      <note xml:id="d1e8554" pname="d" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d1580e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e8573" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e8593" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e8573" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e8593" pname="e" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d1586e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e8612" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e8632" pname="g" oct="3"/>
-                      <note xml:id="d1e8649" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e8612" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e8632" pname="g" oct="3" />
+                      <note xml:id="d1e8649" pname="d" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -1611,28 +1516,25 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d1616e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
-                      <note xml:id="d1e8670" pname="g" oct="4"/>
-                      <note xml:id="d1e8690" pname="g" oct="5"/>
+                      <note xml:id="d1e8670" pname="g" oct="4" />
+                      <note xml:id="d1e8690" pname="g" oct="5" />
                     </chord>
-                    <note xml:id="d1e8707" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e8729" pname="d" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <chord xml:id="d1624e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e8751" pname="f" oct="4"/>
-                      <note xml:id="d1e8774" pname="f" oct="5"/>
+                    <note xml:id="d1e8707" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e8729" pname="d" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <chord xml:id="d1624e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e8751" pname="f" oct="4" />
+                      <note xml:id="d1e8774" pname="f" oct="5" />
                     </chord>
                   </beam>
                   <beam>
-                    <chord xml:id="d1630e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e8794" pname="f" oct="4"/>
-                      <note xml:id="d1e8817" pname="f" oct="5"/>
+                    <chord xml:id="d1630e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
+                      <note xml:id="d1e8794" pname="f" oct="4" />
+                      <note xml:id="d1e8817" pname="f" oct="5" />
                     </chord>
-                    <note xml:id="d1e8837" pname="d" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e8837" pname="d" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d1637e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e8859" pname="f" oct="4"/>
-                      <note xml:id="d1e8877" pname="f" oct="5"/>
+                      <note xml:id="d1e8859" pname="f" oct="4" />
+                      <note xml:id="d1e8877" pname="f" oct="5" />
                     </chord>
                   </beam>
                 </layer>
@@ -1641,59 +1543,53 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d1643e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e8898" pname="b" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e8918" pname="b" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e8898" pname="b" oct="2" accid.ges="f" />
+                      <note xml:id="d1e8918" pname="b" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d1649e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e8937" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e8957" pname="g" oct="3"/>
-                      <note xml:id="d1e8974" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e8937" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e8957" pname="g" oct="3" />
+                      <note xml:id="d1e8974" pname="d" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d1656e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e8993" pname="b" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e9013" pname="b" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e8993" pname="b" oct="2" accid.ges="f" />
+                      <note xml:id="d1e9013" pname="b" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d1662e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e9032" pname="b" accid="n" oct="2">
-                        <accid accid="n"/>
+                      <note xml:id="d1e9032" pname="b" accid.ges="n" oct="2">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e9052" pname="b" accid="n" oct="3">
-                        <accid accid="n"/>
+                      <note xml:id="d1e9052" pname="b" accid.ges="n" oct="3">
+                        <accid accid="n" />
                       </note>
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="1.75" startid="#d1e8751" curvedir="above" tstamp2="0m+2" endid="#d1e8794"
-                staff="1"/>
-              <tie tstamp="1.75" startid="#d1e8774" curvedir="above" tstamp2="0m+2" endid="#d1e8817"
-                staff="1"/>
+              <tie tstamp="1.75" startid="#d1e8751" curvedir="below" tstamp2="0m+2" endid="#d1e8794" staff="1" />
+              <tie tstamp="1.75" startid="#d1e8774" curvedir="above" tstamp2="0m+2" endid="#d1e8817" staff="1" />
             </measure>
             <measure n="25" xml:id="d1e9071" width="59.994">
               <staff n="1">
                 <layer n="1">
-                  <rest xml:id="d1e9073" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e9073" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e9083" pname="c" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e9083" pname="c" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" />
                     <chord xml:id="d1702e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e9103" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e9125" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e9103" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e9125" pname="a" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e9144" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e9144" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e9164" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e9164" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d1710e1" dur="8" dur.ppq="2" stem.dir="down" beam="m1">
-                      <note xml:id="d1e9186" pname="f" oct="4"/>
-                      <note xml:id="d1e9204" pname="f" oct="5"/>
+                      <note xml:id="d1e9186" pname="f" oct="4" />
+                      <note xml:id="d1e9204" pname="f" oct="5" />
                     </chord>
-                    <note xml:id="d1e9221" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e9221" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                 </layer>
               </staff>
@@ -1701,64 +1597,54 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d1717e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e9244" pname="c" oct="3"/>
-                      <note xml:id="d1e9263" pname="c" oct="4"/>
+                      <note xml:id="d1e9244" pname="c" oct="3" />
+                      <note xml:id="d1e9263" pname="c" oct="4" />
                     </chord>
                     <chord xml:id="d1723e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e9280" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e9300" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e9319" pname="c" oct="4"/>
+                      <note xml:id="d1e9280" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e9300" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e9319" pname="c" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d1730e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e9336" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e9356" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e9336" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e9356" pname="e" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d1736e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e9375" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e9395" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e9414" pname="c" oct="4"/>
+                      <note xml:id="d1e9375" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e9395" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e9414" pname="c" oct="4" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
             </measure>
-            <sb/>
-            <scoreDef system.leftmar="4.2" system.rightmar="0" spacing.system="30">
-              <staffGrp>
-                <staffGrp symbol="brace">
-                  <staffDef n="2" spacing="13"/>
-                </staffGrp>
-              </staffGrp>
-            </scoreDef>
+            <sb />
             <measure n="26" xml:id="d1e9431" width="75.76">
               <staff n="1">
                 <layer n="1">
                   <beam>
                     <chord xml:id="d1768e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
-                      <note xml:id="d1e9445" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e9467" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e9445" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e9467" pname="a" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e9486" pname="c" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down"/>
-                    <note xml:id="d1e9506" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <chord xml:id="d1776e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e9528" pname="f" oct="4"/>
-                      <note xml:id="d1e9551" pname="f" oct="5"/>
+                    <note xml:id="d1e9486" pname="c" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" />
+                    <note xml:id="d1e9506" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <chord xml:id="d1776e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e9528" pname="f" oct="4" />
+                      <note xml:id="d1e9551" pname="f" oct="5" />
                     </chord>
                   </beam>
                   <beam>
-                    <chord xml:id="d1782e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e9571" pname="f" oct="4"/>
-                      <note xml:id="d1e9594" pname="f" oct="5"/>
+                    <chord xml:id="d1782e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
+                      <note xml:id="d1e9571" pname="f" oct="4" />
+                      <note xml:id="d1e9594" pname="f" oct="5" />
                     </chord>
-                    <note xml:id="d1e9614" pname="c" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e9614" pname="c" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" />
                     <chord xml:id="d1789e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e9634" pname="f" oct="4"/>
-                      <note xml:id="d1e9653" pname="f" oct="5"/>
+                      <note xml:id="d1e9634" pname="f" oct="4" />
+                      <note xml:id="d1e9653" pname="f" oct="5" />
                     </chord>
                   </beam>
                 </layer>
@@ -1767,63 +1653,57 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d1795e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e9673" pname="a" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e9693" pname="a" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e9673" pname="a" oct="2" accid.ges="f" />
+                      <note xml:id="d1e9693" pname="a" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d1801e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e9712" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e9732" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e9751" pname="c" oct="4"/>
+                      <note xml:id="d1e9712" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e9732" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e9751" pname="c" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d1808e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e9768" pname="a" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e9788" pname="a" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e9768" pname="a" oct="2" accid.ges="f" />
+                      <note xml:id="d1e9788" pname="a" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d1814e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e9807" pname="a" accid="n" oct="2">
-                        <accid accid="n"/>
+                      <note xml:id="d1e9807" pname="a" accid.ges="n" oct="2">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e9827" pname="a" accid="n" oct="3">
-                        <accid accid="n"/>
+                      <note xml:id="d1e9827" pname="a" accid.ges="n" oct="3">
+                        <accid accid="n" />
                       </note>
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="1.75" startid="#d1e9528" curvedir="above" tstamp2="0m+2" endid="#d1e9571"
-                staff="1"/>
-              <tie tstamp="1.75" startid="#d1e9551" curvedir="above" tstamp2="0m+2" endid="#d1e9594"
-                staff="1"/>
+              <tie tstamp="1.75" startid="#d1e9528" curvedir="below" tstamp2="0m+2" endid="#d1e9571" staff="1" />
+              <tie tstamp="1.75" startid="#d1e9551" curvedir="above" tstamp2="0m+2" endid="#d1e9594" staff="1" />
             </measure>
             <measure n="27" xml:id="d1e9846" width="60.906">
               <staff n="1">
                 <layer n="1">
-                  <rest xml:id="d1e9848" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e9848" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e9858" pname="g" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e9858" pname="g" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" />
                     <chord xml:id="d1854e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e9878" pname="e" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e9900" pname="e" oct="6" accid.ges="f"/>
+                      <note xml:id="d1e9878" pname="e" oct="5" accid.ges="f" />
+                      <note xml:id="d1e9900" pname="e" oct="6" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e9919" pname="g" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e9919" pname="g" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e9939" pname="b" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e9939" pname="b" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d1862e1" dur="8" dur.ppq="2" stem.dir="down" beam="m1">
-                      <note xml:id="d1e9961" pname="d" accid="n" oct="5">
-                        <accid accid="n"/>
+                      <note xml:id="d1e9961" pname="d" accid.ges="n" oct="5">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e9981" pname="d" accid="n" oct="6">
-                        <accid accid="n"/>
+                      <note xml:id="d1e9981" pname="d" accid.ges="n" oct="6">
+                        <accid accid="n" />
                       </note>
                     </chord>
-                    <note xml:id="d1e10000" pname="g" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e10000" pname="g" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                 </layer>
               </staff>
@@ -1831,24 +1711,24 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d1869e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e10023" pname="b" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e10044" pname="b" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e10023" pname="b" oct="2" accid.ges="f" />
+                      <note xml:id="d1e10044" pname="b" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d1875e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e10063" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e10083" pname="g" oct="3"/>
-                      <note xml:id="d1e10100" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e10063" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e10083" pname="g" oct="3" />
+                      <note xml:id="d1e10100" pname="d" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d1882e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e10119" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e10139" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e10119" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e10139" pname="e" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d1888e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e10158" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e10178" pname="g" oct="3"/>
-                      <note xml:id="d1e10195" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e10158" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e10178" pname="g" oct="3" />
+                      <note xml:id="d1e10195" pname="d" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -1859,31 +1739,27 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d1918e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
-                      <note xml:id="d1e10216" pname="d" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e10238" pname="d" oct="6" accid.ges="f"/>
+                      <note xml:id="d1e10216" pname="d" oct="5" accid.ges="f" />
+                      <note xml:id="d1e10238" pname="d" oct="6" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e10257" pname="g" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down"/>
-                    <note xml:id="d1e10277" pname="b" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <chord xml:id="d1926e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e10299" pname="c" oct="5"/>
-                      <note xml:id="d1e10322" pname="c" oct="6"/>
+                    <note xml:id="d1e10257" pname="g" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" />
+                    <note xml:id="d1e10277" pname="b" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <chord xml:id="d1926e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e10299" pname="c" oct="5" />
+                      <note xml:id="d1e10322" pname="c" oct="6" />
                     </chord>
                   </beam>
                   <beam>
-                    <chord xml:id="d1932e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e10342" pname="c" oct="5"/>
-                      <note xml:id="d1e10365" pname="c" oct="6"/>
+                    <chord xml:id="d1932e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
+                      <note xml:id="d1e10342" pname="c" oct="5" />
+                      <note xml:id="d1e10365" pname="c" oct="6" />
                     </chord>
-                    <note xml:id="d1e10385" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e10385" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d1939e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e10407" pname="b" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e10429" pname="b" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e10407" pname="b" oct="4" accid.ges="f" />
+                      <note xml:id="d1e10429" pname="b" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e10449" pname="e" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e10449" pname="e" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
@@ -1891,55 +1767,49 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d1946e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e10474" pname="b" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e10494" pname="b" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e10474" pname="b" oct="2" accid.ges="f" />
+                      <note xml:id="d1e10494" pname="b" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d1952e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e10513" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e10533" pname="g" oct="3"/>
-                      <note xml:id="d1e10550" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e10513" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e10533" pname="g" oct="3" />
+                      <note xml:id="d1e10550" pname="d" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d1959e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e10569" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e10589" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e10569" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e10589" pname="e" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d1965e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e10608" pname="g" oct="2"/>
-                      <note xml:id="d1e10626" pname="g" oct="3"/>
+                      <note xml:id="d1e10608" pname="g" oct="2" />
+                      <note xml:id="d1e10626" pname="g" oct="3" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="1.75" startid="#d1e10299" curvedir="above" tstamp2="0m+2"
-                endid="#d1e10342" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e10322" curvedir="above" tstamp2="0m+2"
-                endid="#d1e10365" staff="1"/>
+              <tie tstamp="1.75" startid="#d1e10299" curvedir="below" tstamp2="0m+2" endid="#d1e10342" staff="1" />
+              <tie tstamp="1.75" startid="#d1e10322" curvedir="above" tstamp2="0m+2" endid="#d1e10365" staff="1" />
             </measure>
             <measure n="29" xml:id="d1e10644" width="58.218">
               <staff n="1">
                 <layer n="1">
-                  <rest xml:id="d1e10646" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e10646" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e10656" pname="c" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e10656" pname="c" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" />
                     <chord xml:id="d2005e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e10676" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e10698" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e10676" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e10698" pname="a" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e10717" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e10717" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e10737" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e10737" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d2013e1" dur="8" dur.ppq="2" stem.dir="down" beam="m1">
-                      <note xml:id="d1e10759" pname="f" oct="4"/>
-                      <note xml:id="d1e10777" pname="f" oct="5"/>
+                      <note xml:id="d1e10759" pname="f" oct="4" />
+                      <note xml:id="d1e10777" pname="f" oct="5" />
                     </chord>
-                    <note xml:id="d1e10794" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e10794" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                 </layer>
               </staff>
@@ -1947,61 +1817,54 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d2020e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e10817" pname="a" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e10838" pname="a" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e10817" pname="a" oct="2" accid.ges="f" />
+                      <note xml:id="d1e10838" pname="a" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d2026e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e10857" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e10877" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e10896" pname="c" oct="4"/>
+                      <note xml:id="d1e10857" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e10877" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e10896" pname="c" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d2033e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e10913" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e10933" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e10913" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e10933" pname="e" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d2039e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e10952" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e10972" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e10991" pname="c" oct="4"/>
+                      <note xml:id="d1e10952" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e10972" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e10991" pname="c" oct="4" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
             </measure>
-            <sb/>
-            <scoreDef system.leftmar="4.2" system.rightmar="0" spacing.system="30">
-              <staffGrp>
-                <staffGrp symbol="brace">
-                  <staffDef n="2" spacing="13"/>
-                </staffGrp>
-              </staffGrp>
-            </scoreDef>
+            <sb />
             <measure n="30" xml:id="d1e11008" width="71.514">
               <staff n="1">
                 <layer n="1">
                   <beam>
                     <chord xml:id="d2071e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e11022" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e11042" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e11022" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e11042" pname="a" oct="5" accid.ges="f" />
                     </chord>
                     <chord xml:id="d2077e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e11061" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e11081" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e11061" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e11081" pname="a" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d2083e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e11100" pname="g" oct="4"/>
-                      <note xml:id="d1e11118" pname="g" oct="5"/>
+                      <note xml:id="d1e11100" pname="g" oct="4" />
+                      <note xml:id="d1e11118" pname="g" oct="5" />
                     </chord>
                     <chord xml:id="d2089e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e11135" pname="g" accid="f" oct="4">
-                        <accid accid="f"/>
+                      <note xml:id="d1e11135" pname="g" accid.ges="f" oct="4">
+                        <accid accid="f" />
                       </note>
-                      <note xml:id="d1e11157" pname="g" accid="f" oct="5">
-                        <accid accid="f"/>
+                      <note xml:id="d1e11157" pname="g" accid.ges="f" oct="5">
+                        <accid accid="f" />
                       </note>
                     </chord>
                   </beam>
@@ -2011,25 +1874,25 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d2095e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e11181" pname="a" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e11202" pname="a" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e11181" pname="a" oct="2" accid.ges="f" />
+                      <note xml:id="d1e11202" pname="a" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d2101e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e11221" pname="a" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e11241" pname="a" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e11221" pname="a" oct="2" accid.ges="f" />
+                      <note xml:id="d1e11241" pname="a" oct="3" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d2107e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e11260" pname="g" oct="2"/>
-                      <note xml:id="d1e11278" pname="g" oct="3"/>
+                      <note xml:id="d1e11260" pname="g" oct="2" />
+                      <note xml:id="d1e11278" pname="g" oct="3" />
                     </chord>
                     <chord xml:id="d2113e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e11295" pname="g" accid="f" oct="2">
-                        <accid accid="f"/>
+                      <note xml:id="d1e11295" pname="g" accid.ges="f" oct="2">
+                        <accid accid="f" />
                       </note>
-                      <note xml:id="d1e11317" pname="g" accid="f" oct="3">
-                        <accid accid="f"/>
+                      <note xml:id="d1e11317" pname="g" accid.ges="f" oct="3">
+                        <accid accid="f" />
                       </note>
                     </chord>
                   </beam>
@@ -2039,26 +1902,19 @@
             <measure n="31" xml:id="d1e11338" width="67.184">
               <staff n="1">
                 <layer n="1">
-                  <rest xml:id="d1e11340" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e11340" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e11350" pname="f" oct="4" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="up"/>
-                    <note xml:id="d1e11370" pname="a" accid="n" oct="4" dur="16" dur.ppq="1"
-                      beam="m1" stem.dir="up">
-                      <accid accid="n"/>
+                    <note xml:id="d1e11350" pname="f" oct="4" dur="16" dur.ppq="1" beam="i1" stem.dir="up" />
+                    <note xml:id="d1e11370" pname="a" accid.ges="n" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="up">
+                      <accid accid="n" />
                     </note>
-                    <note xml:id="d1e11392" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="up"/>
+                    <note xml:id="d1e11392" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="up" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e11412" pname="f" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down"/>
-                    <note xml:id="d1e11432" pname="c" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down"/>
-                    <note xml:id="d1e11452" pname="a" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="n"/>
-                    <note xml:id="d1e11472" pname="f" oct="4" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e11412" pname="f" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" />
+                    <note xml:id="d1e11432" pname="c" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" />
+                    <note xml:id="d1e11452" pname="a" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="n" />
+                    <note xml:id="d1e11472" pname="f" oct="4" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                 </layer>
               </staff>
@@ -2066,26 +1922,26 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d2151e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e11495" pname="f" oct="2"/>
-                      <note xml:id="d1e11513" pname="f" oct="3"/>
+                      <note xml:id="d1e11495" pname="f" oct="2" />
+                      <note xml:id="d1e11513" pname="f" oct="3" />
                     </chord>
                     <chord xml:id="d2157e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e11531" pname="f" oct="2"/>
-                      <note xml:id="d1e11549" pname="f" oct="3"/>
+                      <note xml:id="d1e11531" pname="f" oct="2" />
+                      <note xml:id="d1e11549" pname="f" oct="3" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d2163e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e11566" pname="a" accid="n" oct="2">
-                        <accid accid="n"/>
+                      <note xml:id="d1e11566" pname="a" accid.ges="n" oct="2">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e11586" pname="a" accid="n" oct="3">
-                        <accid accid="n"/>
+                      <note xml:id="d1e11586" pname="a" accid.ges="n" oct="3">
+                        <accid accid="n" />
                       </note>
                     </chord>
                     <chord xml:id="d2169e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e11605" pname="a" oct="2" accid.ges="n"/>
-                      <note xml:id="d1e11623" pname="a" oct="3" accid.ges="n"/>
+                      <note xml:id="d1e11605" pname="a" oct="2" accid.ges="n" />
+                      <note xml:id="d1e11623" pname="a" oct="3" accid.ges="n" />
                     </chord>
                   </beam>
                 </layer>
@@ -2094,24 +1950,21 @@
             <measure n="32" xml:id="d1e11640" width="60.232">
               <staff n="1">
                 <layer n="1">
-                  <rest xml:id="d1e11642" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e11642" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e11652" pname="f" oct="4" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="up"/>
-                    <note xml:id="d1e11672" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="up" accid.ges="f"/>
-                    <note xml:id="d1e11694" pname="d" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e11652" pname="f" oct="4" dur="16" dur.ppq="1" beam="i1" stem.dir="up" />
+                    <note xml:id="d1e11672" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="up" accid.ges="f" />
+                    <note xml:id="d1e11694" pname="d" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="up" accid.ges="f" />
                   </beam>
                   <beam>
                     <chord xml:id="d2203e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e11716" pname="f" oct="4"/>
-                      <note xml:id="d1e11734" pname="f" oct="5"/>
+                      <note xml:id="d1e11716" pname="f" oct="4" />
+                      <note xml:id="d1e11734" pname="f" oct="5" />
                     </chord>
                     <chord xml:id="d2209e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e11751" pname="f" oct="4"/>
-                      <note xml:id="d1e11769" pname="b" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e11788" pname="d" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e11751" pname="f" oct="4" />
+                      <note xml:id="d1e11769" pname="b" oct="4" accid.ges="f" />
+                      <note xml:id="d1e11788" pname="d" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -2120,25 +1973,25 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d2216e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e11810" pname="b" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e11831" pname="b" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e11810" pname="b" oct="2" accid.ges="f" />
+                      <note xml:id="d1e11831" pname="b" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d2222e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e11850" pname="f" oct="3"/>
-                      <note xml:id="d1e11868" pname="b" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e11887" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e11850" pname="f" oct="3" />
+                      <note xml:id="d1e11868" pname="b" oct="3" accid.ges="f" />
+                      <note xml:id="d1e11887" pname="d" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d2229e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e11906" pname="f" oct="3"/>
-                      <note xml:id="d1e11924" pname="b" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e11943" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e11906" pname="f" oct="3" />
+                      <note xml:id="d1e11924" pname="b" oct="3" accid.ges="f" />
+                      <note xml:id="d1e11943" pname="d" oct="4" accid.ges="f" />
                     </chord>
                     <chord xml:id="d2236e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e11962" pname="f" oct="3"/>
-                      <note xml:id="d1e11980" pname="b" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e11999" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e11962" pname="f" oct="3" />
+                      <note xml:id="d1e11980" pname="b" oct="3" accid.ges="f" />
+                      <note xml:id="d1e11999" pname="d" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -2149,31 +2002,30 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d2266e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e12020" pname="d" accid="n" oct="4">
-                        <accid accid="n"/>
+                      <note xml:id="d1e12020" pname="d" accid.ges="n" oct="4">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e12040" pname="f" oct="4"/>
-                      <note xml:id="d1e12057" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e12076" pname="c" oct="5"/>
+                      <note xml:id="d1e12040" pname="f" oct="4" />
+                      <note xml:id="d1e12057" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e12076" pname="c" oct="5" />
                     </chord>
-                    <rest xml:id="d1e12093" dur="16" dur.ppq="1" beam="m1"/>
+                    <rest xml:id="d1e12093" dur="16" dur.ppq="1" beam="m1" />
                     <chord xml:id="d2276e1" dur="16" dur.ppq="1" stem.dir="up" beam="t1">
-                      <note xml:id="d1e12103" pname="d" oct="4" accid.ges="n"/>
-                      <note xml:id="d1e12123" pname="f" oct="4"/>
-                      <note xml:id="d1e12140" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e12159" pname="c" oct="5"/>
+                      <note xml:id="d1e12103" pname="d" oct="4" accid.ges="n" />
+                      <note xml:id="d1e12123" pname="f" oct="4" />
+                      <note xml:id="d1e12140" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e12159" pname="c" oct="5" />
                     </chord>
                   </beam>
-                  <rest xml:id="d1e12176" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e12176" dur="16" dur.ppq="1" />
                   <beam>
                     <chord xml:id="d2286e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e12186" pname="d" accid="f" oct="4">
-                        <accid accid="f"/>
+                      <note xml:id="d1e12186" pname="d" accid.ges="f" oct="4">
+                        <accid accid="f" />
                       </note>
-                      <note xml:id="d1e12209" pname="b" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e12209" pname="b" oct="4" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e12228" pname="e" oct="4" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e12228" pname="e" oct="4" dur="16" dur.ppq="1" beam="t1" stem.dir="up" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
@@ -2181,24 +2033,24 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d2293e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e12253" pname="b" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e12273" pname="f" oct="3"/>
-                      <note xml:id="d1e12290" pname="b" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e12253" pname="b" oct="2" accid.ges="f" />
+                      <note xml:id="d1e12273" pname="f" oct="3" />
+                      <note xml:id="d1e12290" pname="b" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d2300e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e12309" pname="b" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e12329" pname="f" oct="3"/>
-                      <note xml:id="d1e12346" pname="b" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e12309" pname="b" oct="2" accid.ges="f" />
+                      <note xml:id="d1e12329" pname="f" oct="3" />
+                      <note xml:id="d1e12346" pname="b" oct="3" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d2307e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e12365" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e12385" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e12365" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e12385" pname="e" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d2313e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e12405" pname="g" oct="2"/>
-                      <note xml:id="d1e12423" pname="g" oct="3"/>
+                      <note xml:id="d1e12405" pname="g" oct="2" />
+                      <note xml:id="d1e12423" pname="g" oct="3" />
                     </chord>
                   </beam>
                 </layer>
@@ -2206,35 +2058,28 @@
             </measure>
           </section>
           <ending n="1">
-            <sb/>
-            <scoreDef system.leftmar="4.2" system.rightmar="0" spacing.system="30">
-              <staffGrp>
-                <staffGrp symbol="brace">
-                  <staffDef n="2" spacing="13"/>
-                </staffGrp>
-              </staffGrp>
-            </scoreDef>
+            <sb />
             <measure n="34" xml:id="d1e12440" right="rptend" width="75.47">
               <staff n="1">
                 <layer n="1">
                   <beam>
                     <chord xml:id="d2344e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e12456" pname="c" oct="4"/>
-                      <note xml:id="d1e12474" pname="a" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e12456" pname="c" oct="4" />
+                      <note xml:id="d1e12474" pname="a" oct="4" accid.ges="f" />
                     </chord>
                     <chord xml:id="d2350e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e12493" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e12513" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e12493" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e12513" pname="e" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d2356e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e12532" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e12552" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e12532" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e12552" pname="e" oct="5" accid.ges="f" />
                     </chord>
                     <chord xml:id="d2362e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e12571" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e12591" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e12571" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e12591" pname="e" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -2243,27 +2088,27 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d2368e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e12614" pname="a" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e12634" pname="a" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e12614" pname="a" oct="2" accid.ges="f" />
+                      <note xml:id="d1e12634" pname="a" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d2374e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e12653" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e12673" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e12692" pname="c" oct="4"/>
+                      <note xml:id="d1e12653" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e12673" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e12692" pname="c" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d2381e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e12709" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e12729" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e12748" pname="c" oct="4"/>
+                      <note xml:id="d1e12709" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e12729" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e12748" pname="c" oct="4" />
                     </chord>
                     <chord xml:id="d2388e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e12765" pname="a" accid="n" oct="2">
-                        <accid accid="n"/>
+                      <note xml:id="d1e12765" pname="a" accid.ges="n" oct="2">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e12785" pname="a" accid="n" oct="3">
-                        <accid accid="n"/>
+                      <note xml:id="d1e12785" pname="a" accid.ges="n" oct="3">
+                        <accid accid="n" />
                       </note>
                     </chord>
                   </beam>
@@ -2275,44 +2120,41 @@
             <measure n="35" xml:id="d1e12809" right="dbl" width="60.216">
               <staff n="1">
                 <layer n="1">
-                  <rest xml:id="d1e12813" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e12813" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e12823" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e12845" pname="c" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down"/>
-                    <note xml:id="d1e12865" pname="e" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e12823" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e12845" pname="c" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" />
+                    <note xml:id="d1e12865" pname="e" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" accid.ges="f" />
                   </beam>
                   <chord xml:id="d2422e1" dur="8" dur.ppq="2" stem.dir="down">
-                    <note xml:id="d1e12887" pname="a" oct="4" accid.ges="f"/>
-                    <note xml:id="d1e12905" pname="a" oct="5" accid.ges="f"/>
+                    <note xml:id="d1e12887" pname="a" oct="4" accid.ges="f" />
+                    <note xml:id="d1e12905" pname="a" oct="5" accid.ges="f" />
                   </chord>
-                  <rest xml:id="d1e12924" dur="8" dur.ppq="2"/>
+                  <rest xml:id="d1e12924" dur="8" dur.ppq="2" />
                 </layer>
               </staff>
               <staff n="2">
                 <layer n="1">
                   <beam>
                     <chord xml:id="d2430e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e12937" pname="a" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e12957" pname="a" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e12937" pname="a" oct="2" accid.ges="f" />
+                      <note xml:id="d1e12957" pname="a" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d2436e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e12977" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e12997" pname="c" oct="4"/>
-                      <note xml:id="d1e13014" pname="e" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e12977" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e12997" pname="c" oct="4" />
+                      <note xml:id="d1e13014" pname="e" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d2443e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e13033" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e13053" pname="c" oct="4"/>
-                      <note xml:id="d1e13070" pname="e" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e13033" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e13053" pname="c" oct="4" />
+                      <note xml:id="d1e13070" pname="e" oct="4" accid.ges="f" />
                     </chord>
                     <chord xml:id="d2450e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e13089" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e13109" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e13089" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e13109" pname="e" oct="3" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -2323,26 +2165,22 @@
             <measure n="36" xml:id="d1e13132" width="62.56">
               <staff n="1">
                 <layer n="1">
-                  <rest xml:id="d1e13141" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e13141" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e13151" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e13151" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1" stem.dir="up" accid.ges="f" />
                     <chord xml:id="d2478e1" dur="16" dur.ppq="1" stem.dir="up" beam="m1">
-                      <note xml:id="d1e13173" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e13195" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e13173" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e13195" pname="e" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e13214" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e13214" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1" stem.dir="up" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e13236" pname="c" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="up"/>
+                    <note xml:id="d1e13236" pname="c" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="up" />
                     <chord xml:id="d2486e1" dur="8" dur.ppq="2" stem.dir="up" beam="m1">
-                      <note xml:id="d1e13256" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e13276" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e13256" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e13276" pname="e" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e13295" pname="g" oct="4" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="up"/>
+                    <note xml:id="d1e13295" pname="g" oct="4" dur="16" dur.ppq="1" beam="t1" stem.dir="up" />
                   </beam>
                 </layer>
               </staff>
@@ -2350,27 +2188,27 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d2493e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e13319" pname="a" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e13339" pname="a" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e13319" pname="a" oct="2" accid.ges="f" />
+                      <note xml:id="d1e13339" pname="a" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d2499e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e13358" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e13378" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e13397" pname="c" oct="4"/>
+                      <note xml:id="d1e13358" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e13378" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e13397" pname="c" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d2506e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e13414" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e13434" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e13453" pname="c" oct="4"/>
+                      <note xml:id="d1e13414" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e13434" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e13453" pname="c" oct="4" />
                     </chord>
                     <chord xml:id="d2513e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e13470" pname="a" accid="n" oct="2">
-                        <accid accid="n"/>
+                      <note xml:id="d1e13470" pname="a" accid.ges="n" oct="2">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e13490" pname="a" accid="n" oct="3">
-                        <accid accid="n"/>
+                      <note xml:id="d1e13490" pname="a" accid.ges="n" oct="3">
+                        <accid accid="n" />
                       </note>
                     </chord>
                   </beam>
@@ -2383,21 +2221,19 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d2544e1" dur="16" dur.ppq="1" stem.dir="up" beam="i1">
-                      <note xml:id="d1e13511" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e13533" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e13511" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e13533" pname="e" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e13552" pname="g" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="up"/>
-                    <note xml:id="d1e13572" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="up" accid.ges="f"/>
-                    <chord xml:id="d2552e1" dur="16" dur.ppq="1" stem.dir="up" beam="t1" tie="i">
-                      <note xml:id="d1e13594" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e13619" pname="e" oct="5" accid.ges="f"/>
+                    <note xml:id="d1e13552" pname="g" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="up" />
+                    <note xml:id="d1e13572" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="up" accid.ges="f" />
+                    <chord xml:id="d2552e1" dur="16" dur.ppq="1" stem.dir="up" beam="t1">
+                      <note xml:id="d1e13594" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e13619" pname="e" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
-                  <chord xml:id="d2558e1" dur="4" dur.ppq="4" stem.dir="up" tie="t">
-                    <note xml:id="d1e13641" pname="e" oct="4" accid.ges="f"/>
-                    <note xml:id="d1e13662" pname="e" oct="5" accid.ges="f"/>
+                  <chord xml:id="d2558e1" dur="4" dur.ppq="4" stem.dir="up">
+                    <note xml:id="d1e13641" pname="e" oct="4" accid.ges="f" />
+                    <note xml:id="d1e13662" pname="e" oct="5" accid.ges="f" />
                   </chord>
                 </layer>
               </staff>
@@ -2405,64 +2241,51 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d2564e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e13687" pname="b" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e13707" pname="b" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e13687" pname="b" oct="2" accid.ges="f" />
+                      <note xml:id="d1e13707" pname="b" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d2570e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e13727" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e13747" pname="g" oct="3"/>
-                      <note xml:id="d1e13764" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e13727" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e13747" pname="g" oct="3" />
+                      <note xml:id="d1e13764" pname="d" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d2577e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e13783" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e13803" pname="g" oct="3"/>
-                      <note xml:id="d1e13820" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e13783" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e13803" pname="g" oct="3" />
+                      <note xml:id="d1e13820" pname="d" oct="4" accid.ges="f" />
                     </chord>
                     <chord xml:id="d2584e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e13839" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e13859" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e13839" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e13859" pname="e" oct="3" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="1.75" startid="#d1e13594" curvedir="below" tstamp2="0m+2"
-                endid="#d1e13641" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e13619" curvedir="below" tstamp2="0m+2"
-                endid="#d1e13662" staff="1"/>
+              <tie tstamp="1.75" startid="#d1e13594" curvedir="below" tstamp2="0m+2" endid="#d1e13641" staff="1" />
+              <tie tstamp="1.75" startid="#d1e13619" curvedir="above" tstamp2="0m+2" endid="#d1e13662" staff="1" />
             </measure>
-            <sb/>
-            <scoreDef system.leftmar="4.2" system.rightmar="0" spacing.system="30">
-              <staffGrp>
-                <staffGrp symbol="brace">
-                  <staffDef n="2" spacing="13"/>
-                </staffGrp>
-              </staffGrp>
-            </scoreDef>
+            <sb />
             <measure n="38" xml:id="d1e13878" width="71.936">
               <staff n="1">
                 <layer n="1">
-                  <rest xml:id="d1e13892" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e13892" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e13902" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e13902" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1" stem.dir="up" accid.ges="f" />
                     <chord xml:id="d2622e1" dur="16" dur.ppq="1" stem.dir="up" beam="m1">
-                      <note xml:id="d1e13924" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e13946" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e13924" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e13946" pname="e" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e13965" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e13965" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1" stem.dir="up" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e13987" pname="c" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="up"/>
+                    <note xml:id="d1e13987" pname="c" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="up" />
                     <chord xml:id="d2630e1" dur="8" dur.ppq="2" stem.dir="up" beam="m1">
-                      <note xml:id="d1e14007" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e14027" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e14007" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e14027" pname="e" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e14046" pname="g" oct="4" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="up"/>
+                    <note xml:id="d1e14046" pname="g" oct="4" dur="16" dur.ppq="1" beam="t1" stem.dir="up" />
                   </beam>
                 </layer>
               </staff>
@@ -2470,27 +2293,27 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d2637e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e14070" pname="a" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e14090" pname="a" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e14070" pname="a" oct="2" accid.ges="f" />
+                      <note xml:id="d1e14090" pname="a" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d2643e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e14109" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e14129" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e14148" pname="c" oct="4"/>
+                      <note xml:id="d1e14109" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e14129" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e14148" pname="c" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d2650e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e14165" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e14185" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e14204" pname="c" oct="4"/>
+                      <note xml:id="d1e14165" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e14185" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e14204" pname="c" oct="4" />
                     </chord>
                     <chord xml:id="d2657e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e14221" pname="a" accid="n" oct="2">
-                        <accid accid="n"/>
+                      <note xml:id="d1e14221" pname="a" accid.ges="n" oct="2">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e14241" pname="a" accid="n" oct="3">
-                        <accid accid="n"/>
+                      <note xml:id="d1e14241" pname="a" accid.ges="n" oct="3">
+                        <accid accid="n" />
                       </note>
                     </chord>
                   </beam>
@@ -2502,27 +2325,25 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d2686e1" dur="16" dur.ppq="1" stem.dir="up" beam="i1">
-                      <note xml:id="d1e14262" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e14284" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e14262" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e14284" pname="e" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e14303" pname="g" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="up"/>
-                    <note xml:id="d1e14323" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="up" accid.ges="f"/>
-                    <chord xml:id="d2694e1" dur="16" dur.ppq="1" stem.dir="up" beam="t1" tie="i">
-                      <note xml:id="d1e14345" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e14370" pname="e" oct="5" accid.ges="f"/>
+                    <note xml:id="d1e14303" pname="g" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="up" />
+                    <note xml:id="d1e14323" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="up" accid.ges="f" />
+                    <chord xml:id="d2694e1" dur="16" dur.ppq="1" stem.dir="up" beam="t1">
+                      <note xml:id="d1e14345" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e14370" pname="e" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
-                    <chord xml:id="d2700e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1" tie="t">
-                      <note xml:id="d1e14392" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e14415" pname="e" oct="5" accid.ges="f"/>
+                    <chord xml:id="d2700e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
+                      <note xml:id="d1e14392" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e14415" pname="e" oct="5" accid.ges="f" />
                     </chord>
-                    <rest xml:id="d1e14437" dur="16" dur.ppq="1" beam="m1"/>
+                    <rest xml:id="d1e14437" dur="16" dur.ppq="1" beam="m1" />
                     <chord xml:id="d2708e1" dur="16" dur.ppq="1" stem.dir="up" beam="t1">
-                      <note xml:id="d1e14447" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e14469" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e14447" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e14469" pname="e" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -2531,63 +2352,59 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d2714e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e14492" pname="b" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e14512" pname="b" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e14492" pname="b" oct="2" accid.ges="f" />
+                      <note xml:id="d1e14512" pname="b" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d2720e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e14531" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e14551" pname="g" oct="3"/>
-                      <note xml:id="d1e14568" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e14531" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e14551" pname="g" oct="3" />
+                      <note xml:id="d1e14568" pname="d" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d2727e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e14587" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e14607" pname="g" oct="3"/>
-                      <note xml:id="d1e14624" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e14587" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e14607" pname="g" oct="3" />
+                      <note xml:id="d1e14624" pname="d" oct="4" accid.ges="f" />
                     </chord>
                     <chord xml:id="d2734e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e14643" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e14663" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e14643" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e14663" pname="e" oct="3" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="1.75" startid="#d1e14345" curvedir="below" tstamp2="0m+2"
-                endid="#d1e14392" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e14370" curvedir="below" tstamp2="0m+2"
-                endid="#d1e14415" staff="1"/>
+              <tie tstamp="1.75" startid="#d1e14345" curvedir="below" tstamp2="0m+2" endid="#d1e14392" staff="1" />
+              <tie tstamp="1.75" startid="#d1e14370" curvedir="above" tstamp2="0m+2" endid="#d1e14415" staff="1" />
             </measure>
             <measure n="40" xml:id="d1e14683" width="65.254">
               <staff n="1">
                 <layer n="1">
-                  <rest xml:id="d1e14685" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e14685" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e14695" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e14717" pname="c" accid="f" oct="5" dur="16" dur.ppq="1"
-                      beam="m1" stem.dir="down">
-                      <accid accid="f"/>
+                    <note xml:id="d1e14695" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e14717" pname="c" accid.ges="f" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down">
+                      <accid accid="f" />
                     </note>
                     <chord xml:id="d2775e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
-                      <note xml:id="d1e14741" pname="f" accid="f" oct="4">
-                        <accid accid="f"/>
+                      <note xml:id="d1e14741" pname="f" accid.ges="f" oct="4">
+                        <accid accid="f" />
                       </note>
-                      <note xml:id="d1e14765" pname="f" accid="f" oct="5">
-                        <accid accid="f"/>
+                      <note xml:id="d1e14765" pname="f" accid.ges="f" oct="5">
+                        <accid accid="f" />
                       </note>
                     </chord>
                   </beam>
-                  <rest xml:id="d1e14786" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e14786" dur="16" dur.ppq="1" />
                   <beam>
                     <chord xml:id="d2783e1" dur="16" dur.ppq="1" stem.dir="up" beam="i1">
-                      <note xml:id="d1e14796" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e14818" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e14796" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e14818" pname="e" oct="5" accid.ges="f" />
                     </chord>
-                    <rest xml:id="d1e14837" dur="16" dur.ppq="1" beam="m1"/>
+                    <rest xml:id="d1e14837" dur="16" dur.ppq="1" beam="m1" />
                     <chord xml:id="d2791e1" dur="16" dur.ppq="1" stem.dir="up" beam="t1">
-                      <note xml:id="d1e14847" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e14869" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e14847" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e14869" pname="e" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -2595,21 +2412,21 @@
               <staff n="2">
                 <layer n="1">
                   <chord xml:id="d2797e1" dur="4" dur.ppq="4" stem.dir="up">
-                    <note xml:id="d1e14892" pname="f" accid="f" oct="2">
-                      <accid accid="f"/>
+                    <note xml:id="d1e14892" pname="f" accid.ges="f" oct="2">
+                      <accid accid="f" />
                     </note>
-                    <note xml:id="d1e14912" pname="f" accid="f" oct="3">
-                      <accid accid="f"/>
+                    <note xml:id="d1e14912" pname="f" accid.ges="f" oct="3">
+                      <accid accid="f" />
                     </note>
                   </chord>
                   <beam>
                     <chord xml:id="d2803e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e14933" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e14953" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e14933" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e14953" pname="e" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d2809e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e14972" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e14992" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e14972" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e14992" pname="e" oct="3" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -2618,171 +2435,143 @@
             <measure n="41" xml:id="d1e15011" width="63.456">
               <staff n="1">
                 <layer n="1">
-                  <rest xml:id="d1e15013" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e15013" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e15023" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e15045" pname="c" accid="f" oct="5" dur="16" dur.ppq="1"
-                      beam="m1" stem.dir="down">
-                      <accid accid="f"/>
+                    <note xml:id="d1e15023" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e15045" pname="c" accid.ges="f" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down">
+                      <accid accid="f" />
                     </note>
                     <chord xml:id="d2838e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
-                      <note xml:id="d1e15069" pname="f" accid="f" oct="4">
-                        <accid accid="f"/>
+                      <note xml:id="d1e15069" pname="f" accid.ges="f" oct="4">
+                        <accid accid="f" />
                       </note>
-                      <note xml:id="d1e15093" pname="f" accid="f" oct="5">
-                        <accid accid="f"/>
+                      <note xml:id="d1e15093" pname="f" accid.ges="f" oct="5">
+                        <accid accid="f" />
                       </note>
                     </chord>
                   </beam>
-                  <rest xml:id="d1e15114" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e15114" dur="16" dur.ppq="1" />
                   <chord xml:id="d2846e1" dur="16" dur.ppq="1" stem.dir="up">
-                    <note xml:id="d1e15124" pname="e" oct="4" accid.ges="f"/>
-                    <note xml:id="d1e15142" pname="e" oct="5" accid.ges="f"/>
+                    <note xml:id="d1e15124" pname="e" oct="4" accid.ges="f" />
+                    <note xml:id="d1e15142" pname="e" oct="5" accid.ges="f" />
                   </chord>
-                  <rest xml:id="d1e15161" dur="8" dur.ppq="2"/>
+                  <rest xml:id="d1e15161" dur="8" dur.ppq="2" />
                 </layer>
               </staff>
               <staff n="2">
                 <layer n="1">
                   <chord xml:id="d2854e1" dur="4" dur.ppq="4" stem.dir="up">
-                    <note xml:id="d1e15174" pname="f" accid="f" oct="2">
-                      <accid accid="f"/>
+                    <note xml:id="d1e15174" pname="f" accid.ges="f" oct="2">
+                      <accid accid="f" />
                     </note>
-                    <note xml:id="d1e15195" pname="f" accid="f" oct="3">
-                      <accid accid="f"/>
+                    <note xml:id="d1e15195" pname="f" accid.ges="f" oct="3">
+                      <accid accid="f" />
                     </note>
                   </chord>
                   <chord xml:id="d2860e1" dur="8" dur.ppq="2" stem.dir="up">
-                    <note xml:id="d1e15216" pname="e" oct="2" accid.ges="f"/>
-                    <note xml:id="d1e15234" pname="e" oct="3" accid.ges="f"/>
+                    <note xml:id="d1e15216" pname="e" oct="2" accid.ges="f" />
+                    <note xml:id="d1e15234" pname="e" oct="3" accid.ges="f" />
                   </chord>
-                  <rest xml:id="d1e15253" dur="8" dur.ppq="2"/>
+                  <rest xml:id="d1e15253" dur="8" dur.ppq="2" />
                 </layer>
               </staff>
             </measure>
-            <pb/>
-            <scoreDef system.leftmar="4.2" system.rightmar="0" system.topmar="14">
-              <staffGrp>
-                <staffGrp symbol="brace">
-                  <staffDef n="2" spacing="13"/>
-                </staffGrp>
-              </staffGrp>
-            </scoreDef>
+            <pb />
             <measure n="42" xml:id="d1e15263" width="76.248">
               <staff n="1">
                 <layer n="1">
-                  <mRest xml:id="d1e15277" dur="2" dur.ppq="8"/>
-                  <space xml:id="d1e15485" dur="8" dur.ppq="2"/>
+                  <mRest xml:id="d1e15277" dur="2" dur.ppq="8" />
+                  <space xml:id="d1e15485" dur="8" dur.ppq="2" />
                 </layer>
               </staff>
               <staff n="2">
                 <layer n="1">
-                  <rest xml:id="d1e15295" dur="16" dur.ppq="1" ploc="g" oloc="2"/>
+                  <rest xml:id="d1e15295" dur="16" dur.ppq="1" ploc="g" oloc="2" />
                   <beam>
-                    <note xml:id="d1e15309" pname="a" oct="2" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="up" accid.ges="f"/>
-                    <note xml:id="d1e15333" pname="c" accid="f" oct="3" dur="16" dur.ppq="1"
-                      beam="m1" stem.dir="up">
-                      <accid accid="f"/>
+                    <note xml:id="d1e15309" pname="a" oct="2" dur="16" dur.ppq="1" beam="i1" stem.dir="up" accid.ges="f" />
+                    <note xml:id="d1e15333" pname="c" accid.ges="f" oct="3" dur="16" dur.ppq="1" beam="m1" stem.dir="up">
+                      <accid accid="f" />
                     </note>
-                    <note xml:id="d1e15357" pname="a" oct="3" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e15357" pname="a" oct="3" dur="16" dur.ppq="1" beam="t1" stem.dir="up" accid.ges="f" />
                   </beam>
-                  <rest xml:id="d1e15381" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e15381" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e15391" pname="a" oct="3" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="up" accid.ges="f"/>
-                    <note xml:id="d1e15415" pname="c" accid="f" oct="4" dur="16" dur.ppq="1"
-                      beam="m1" stem.dir="up">
-                      <accid accid="f"/>
+                    <note xml:id="d1e15391" pname="a" oct="3" dur="16" dur.ppq="1" beam="i1" stem.dir="up" accid.ges="f" />
+                    <note xml:id="d1e15415" pname="c" accid.ges="f" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="up">
+                      <accid accid="f" />
                     </note>
-                    <note xml:id="d1e15440" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e15440" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1" stem.dir="up" accid.ges="f" />
                   </beam>
                 </layer>
                 <layer n="2">
-                  <note xml:id="d1e15467" pname="a" oct="1" dur="8" dur.ppq="2" stem.dir="down"
-                    accid.ges="f"/>
-                  <note xml:id="d1e15488" pname="a" oct="2" dur="8" dur.ppq="2" stem.dir="down"
-                    accid.ges="f"/>
-                  <rest xml:id="d1e15506" dur="8" dur.ppq="2"/>
+                  <note xml:id="d1e15467" pname="a" oct="1" dur="8" dur.ppq="2" stem.dir="down" accid.ges="f" />
+                  <rest xml:id="d1e15476" dur="8" dur.ppq="2" />
+                  <note xml:id="d1e15488" pname="a" oct="2" dur="8" dur.ppq="2" stem.dir="down" accid.ges="f" />
+                  <rest xml:id="d1e15506" dur="8" dur.ppq="2" />
                 </layer>
               </staff>
               <dynam label="direction" tstamp="1" place="above" staff="2" val="49">p</dynam>
-              <slur tstamp="1.25" startid="#d1e15309" curvedir="below" tstamp2="0m+1.75"
-                endid="#d1e15357" staff="2"/>
-              <slur tstamp="2.25" startid="#d1e15391" curvedir="below" tstamp2="0m+2.75"
-                endid="#d1e15440" staff="2"/>
+              <slur tstamp="1.25" startid="#d1e15309" curvedir="below" tstamp2="0m+1.75" endid="#d1e15357" staff="2" />
+              <slur tstamp="2.25" startid="#d1e15391" curvedir="below" tstamp2="0m+2.75" endid="#d1e15440" staff="2" />
             </measure>
             <measure n="43" xml:id="d1e15516" width="61.11">
               <staff n="1">
                 <layer n="1">
-                  <rest xml:id="d1e15518" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e15518" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e15528" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e15552" pname="c" accid="f" oct="5" dur="16" dur.ppq="1"
-                      beam="m1" stem.dir="down">
-                      <accid accid="f"/>
+                    <note xml:id="d1e15528" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e15552" pname="c" accid.ges="f" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down">
+                      <accid accid="f" />
                     </note>
-                    <note xml:id="d1e15576" pname="a" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e15576" pname="a" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" accid.ges="f" />
                   </beam>
-                  <rest xml:id="d1e15600" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e15600" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e15610" pname="a" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e15634" pname="c" accid="f" oct="6" dur="16" dur.ppq="1"
-                      beam="m1" stem.dir="down">
-                      <accid accid="f"/>
+                    <note xml:id="d1e15610" pname="a" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e15634" pname="c" accid.ges="f" oct="6" dur="16" dur.ppq="1" beam="m1" stem.dir="down">
+                      <accid accid="f" />
                     </note>
-                    <note xml:id="d1e15658" pname="a" oct="6" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e15658" pname="a" oct="6" dur="16" dur.ppq="1" beam="t1" stem.dir="down" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
               <staff n="2">
                 <layer n="1">
-                  <note xml:id="d1e15685" pname="a" oct="3" dur="8" dur.ppq="2" stem.dir="down"
-                    accid.ges="f"/>
-                  <rest xml:id="d1e15703" dur="8" dur.ppq="2"/>
-                  <note xml:id="d1e15714" pname="a" oct="4" dur="8" dur.ppq="2" stem.dir="down"
-                    accid.ges="f"/>
-                  <rest xml:id="d1e15732" dur="8" dur.ppq="2"/>
+                  <note xml:id="d1e15685" pname="a" oct="3" dur="8" dur.ppq="2" stem.dir="down" accid.ges="f" />
+                  <rest xml:id="d1e15703" dur="8" dur.ppq="2" />
+                  <note xml:id="d1e15714" pname="a" oct="4" dur="8" dur.ppq="2" stem.dir="down" accid.ges="f" />
+                  <rest xml:id="d1e15732" dur="8" dur.ppq="2" />
+                  <clef line="2" shape="G" />
                 </layer>
               </staff>
-              <slur tstamp="1.25" startid="#d1e15528" curvedir="above" tstamp2="0m+1.75"
-                endid="#d1e15576" staff="1"/>
-              <slur tstamp="2.25" startid="#d1e15610" curvedir="above" tstamp2="0m+2.75"
-                endid="#d1e15658" staff="1"/>
+              <slur tstamp="1.25" startid="#d1e15528" curvedir="above" tstamp2="0m+1.75" endid="#d1e15576" staff="1" />
+              <slur tstamp="2.25" startid="#d1e15610" curvedir="above" tstamp2="0m+2.75" endid="#d1e15658" staff="1" />
             </measure>
-            <staffDef n="2" clef.line="2" clef.shape="G"/>
             <measure n="44" xml:id="d1e15742" width="61.428">
               <staff n="1">
                 <layer n="1">
                   <beam>
                     <chord xml:id="d2966e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e15757" pname="a" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e15777" pname="a" oct="6" accid.ges="f"/>
+                      <note xml:id="d1e15757" pname="a" oct="5" accid.ges="f" />
+                      <note xml:id="d1e15777" pname="a" oct="6" accid.ges="f" />
                     </chord>
                     <chord xml:id="d2972e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e15801" pname="a" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e15821" pname="a" oct="6" accid.ges="f"/>
+                      <note xml:id="d1e15801" pname="a" oct="5" accid.ges="f" />
+                      <note xml:id="d1e15821" pname="a" oct="6" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d2978e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e15840" pname="a" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e15860" pname="a" oct="6" accid.ges="f"/>
+                      <note xml:id="d1e15840" pname="a" oct="5" accid.ges="f" />
+                      <note xml:id="d1e15860" pname="a" oct="6" accid.ges="f" />
                     </chord>
                     <chord xml:id="d2984e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e15879" pname="a" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e15901" pname="a" oct="6" accid.ges="f"/>
+                      <note xml:id="d1e15879" pname="a" oct="5" accid.ges="f" />
+                      <note xml:id="d1e15901" pname="a" oct="6" accid.ges="f" />
                     </chord>
-                    <chord xml:id="d2990e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e15921" pname="a" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e15946" pname="a" oct="6" accid.ges="f"/>
+                    <chord xml:id="d2990e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e15921" pname="a" oct="5" accid.ges="f" />
+                      <note xml:id="d1e15946" pname="a" oct="6" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -2791,73 +2580,66 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d2996e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e15976" pname="d" accid="n" oct="4">
-                        <accid accid="n"/>
+                      <note xml:id="d1e15976" pname="d" accid.ges="n" oct="4">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e15996" pname="f" oct="4"/>
-                      <note xml:id="d1e16013" pname="a" accid="n" oct="4">
-                        <accid accid="n"/>
+                      <note xml:id="d1e15996" pname="f" oct="4" />
+                      <note xml:id="d1e16013" pname="a" accid.ges="n" oct="4">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e16032" pname="b" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e16032" pname="b" oct="4" accid.ges="f" />
                     </chord>
                     <chord xml:id="d3004e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e16051" pname="d" oct="4" accid.ges="n"/>
-                      <note xml:id="d1e16069" pname="f" oct="4"/>
-                      <note xml:id="d1e16086" pname="a" oct="4" accid.ges="n"/>
-                      <note xml:id="d1e16104" pname="b" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e16051" pname="d" oct="4" accid.ges="n" />
+                      <note xml:id="d1e16069" pname="f" oct="4" />
+                      <note xml:id="d1e16086" pname="a" oct="4" accid.ges="n" />
+                      <note xml:id="d1e16104" pname="b" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d3012e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e16123" pname="d" oct="4" accid.ges="n"/>
-                      <note xml:id="d1e16141" pname="f" oct="4"/>
-                      <note xml:id="d1e16158" pname="a" oct="4" accid.ges="n"/>
-                      <note xml:id="d1e16175" pname="b" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e16123" pname="d" oct="4" accid.ges="n" />
+                      <note xml:id="d1e16141" pname="f" oct="4" />
+                      <note xml:id="d1e16158" pname="a" oct="4" accid.ges="n" />
+                      <note xml:id="d1e16175" pname="b" oct="4" accid.ges="f" />
                     </chord>
                     <chord xml:id="d3020e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e16194" pname="d" oct="4" accid.ges="n"/>
-                      <note xml:id="d1e16212" pname="f" oct="4"/>
-                      <note xml:id="d1e16229" pname="a" oct="4" accid.ges="n"/>
-                      <note xml:id="d1e16246" pname="b" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e16194" pname="d" oct="4" accid.ges="n" />
+                      <note xml:id="d1e16212" pname="f" oct="4" />
+                      <note xml:id="d1e16229" pname="a" oct="4" accid.ges="n" />
+                      <note xml:id="d1e16246" pname="b" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
               <dynam label="direction" tstamp="1" place="below" staff="1" val="80">mf</dynam>
-              <hairpin tstamp="1.5" place="below" staff="1" form="cres" tstamp2="0m+3"
-                endid="#d1e15946"/>
-              <tie tstamp="2.75" startid="#d1e15921" curvedir="above" tstamp2="1m+1"
-                endid="#d1e16267" staff="1"/>
-              <tie tstamp="2.75" startid="#d1e15946" curvedir="above" tstamp2="1m+1"
-                endid="#d1e16292" staff="1"/>
+              <hairpin tstamp="1.5" place="below" staff="1" form="cres" tstamp2="0m+3" endid="#d1e15946" />
+              <tie tstamp="2.75" startid="#d1e15921" curvedir="below" tstamp2="1m+1" endid="#d1e16267" staff="1" />
+              <tie tstamp="2.75" startid="#d1e15946" curvedir="above" tstamp2="1m+1" endid="#d1e16292" staff="1" />
             </measure>
             <measure n="45" xml:id="d1e16265" width="61.592">
               <staff n="1">
                 <layer n="1">
                   <beam>
-                    <chord xml:id="d3064e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e16267" pname="a" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e16292" pname="a" oct="6" accid.ges="f"/>
+                    <chord xml:id="d3064e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
+                      <note xml:id="d1e16267" pname="a" oct="5" accid.ges="f" />
+                      <note xml:id="d1e16292" pname="a" oct="6" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e16314" pname="e" oct="6" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e16336" pname="f" oct="6" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down"/>
-                    <note xml:id="d1e16356" pname="c" oct="6" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e16314" pname="e" oct="6" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e16336" pname="f" oct="6" dur="16" dur.ppq="1" beam="m1" stem.dir="down" />
+                    <note xml:id="d1e16356" pname="c" oct="6" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e16376" pname="e" oct="6" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e16376" pname="e" oct="6" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d3074e1" dur="8" dur.ppq="2" stem.dir="down" beam="m1">
-                      <note xml:id="d1e16398" pname="a" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e16418" pname="f" oct="6"/>
+                      <note xml:id="d1e16398" pname="a" oct="5" accid.ges="f" />
+                      <note xml:id="d1e16418" pname="f" oct="6" />
                     </chord>
-                    <chord xml:id="d3080e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e16435" pname="f" accid="f" oct="5">
-                        <accid accid="f"/>
+                    <chord xml:id="d3080e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e16435" pname="f" accid.ges="f" oct="5">
+                        <accid accid="f" />
                       </note>
-                      <note xml:id="d1e16462" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e16462" pname="a" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -2866,75 +2648,62 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d3086e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e16488" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e16508" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e16527" pname="c" oct="5"/>
+                      <note xml:id="d1e16488" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e16508" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e16527" pname="c" oct="5" />
                     </chord>
                     <chord xml:id="d3093e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e16544" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e16564" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e16583" pname="c" oct="5"/>
+                      <note xml:id="d1e16544" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e16564" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e16583" pname="c" oct="5" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d3100e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e16600" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e16620" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e16639" pname="c" oct="5"/>
+                      <note xml:id="d1e16600" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e16620" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e16639" pname="c" oct="5" />
                     </chord>
                     <chord xml:id="d3107e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e16656" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e16676" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e16696" pname="c" oct="5"/>
+                      <note xml:id="d1e16656" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e16676" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e16696" pname="c" oct="5" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="2.75" startid="#d1e16435" curvedir="above" tstamp2="1m+1"
-                endid="#d1e16727" staff="1"/>
-              <tie tstamp="2.75" startid="#d1e16462" curvedir="above" tstamp2="1m+1"
-                endid="#d1e16752" staff="1"/>
+              <tie tstamp="2.75" startid="#d1e16435" curvedir="below" tstamp2="1m+1" endid="#d1e16727" staff="1" />
+              <tie tstamp="2.75" startid="#d1e16462" curvedir="above" tstamp2="1m+1" endid="#d1e16752" staff="1" />
             </measure>
-            <sb/>
-            <scoreDef system.leftmar="4.2" system.rightmar="0" spacing.system="30">
-              <staffGrp>
-                <staffGrp symbol="brace">
-                  <staffDef n="2" spacing="13"/>
-                </staffGrp>
-              </staffGrp>
-            </scoreDef>
+            <sb />
             <measure n="46" xml:id="d1e16713" width="84.762">
               <staff n="1">
                 <layer n="1">
                   <beam>
-                    <chord xml:id="d3147e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e16727" pname="f" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e16752" pname="a" oct="5" accid.ges="f"/>
+                    <chord xml:id="d3147e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
+                      <note xml:id="d1e16727" pname="f" oct="5" accid.ges="f" />
+                      <note xml:id="d1e16752" pname="a" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e16774" pname="b" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e16774" pname="b" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d3154e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e16796" pname="f" accid="f" oct="5">
-                        <accid accid="f"/>
+                      <note xml:id="d1e16796" pname="f" accid.ges="f" oct="5">
+                        <accid accid="f" />
                       </note>
-                      <note xml:id="d1e16820" pname="c" accid="f" oct="6">
-                        <accid accid="f"/>
+                      <note xml:id="d1e16820" pname="c" accid.ges="f" oct="6">
+                        <accid accid="f" />
                       </note>
                     </chord>
-                    <note xml:id="d1e16841" pname="a" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e16841" pname="a" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e16863" pname="b" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e16863" pname="b" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d3162e1" dur="8" dur.ppq="2" stem.dir="down" beam="m1">
-                      <note xml:id="d1e16885" pname="e" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e16905" pname="c" accid="n" oct="6">
-                        <accid accid="n"/>
+                      <note xml:id="d1e16885" pname="e" oct="5" accid.ges="f" />
+                      <note xml:id="d1e16905" pname="c" accid.ges="n" oct="6">
+                        <accid accid="n" />
                       </note>
                     </chord>
-                    <note xml:id="d1e16924" pname="a" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e16924" pname="a" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
@@ -2942,32 +2711,32 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d3169e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e16950" pname="f" accid="f" oct="4">
-                        <accid accid="f"/>
+                      <note xml:id="d1e16950" pname="f" accid.ges="f" oct="4">
+                        <accid accid="f" />
                       </note>
-                      <note xml:id="d1e16972" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e16991" pname="c" accid="f" oct="5">
-                        <accid accid="f"/>
+                      <note xml:id="d1e16972" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e16991" pname="c" accid.ges="f" oct="5">
+                        <accid accid="f" />
                       </note>
                     </chord>
                     <chord xml:id="d3176e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e17012" pname="f" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e17032" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e17051" pname="c" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e17012" pname="f" oct="4" accid.ges="f" />
+                      <note xml:id="d1e17032" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e17051" pname="c" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d3183e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e17070" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e17090" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e17109" pname="c" accid="n" oct="5">
-                        <accid accid="n"/>
+                      <note xml:id="d1e17070" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e17090" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e17109" pname="c" accid.ges="n" oct="5">
+                        <accid accid="n" />
                       </note>
                     </chord>
                     <chord xml:id="d3190e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e17128" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e17149" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e17168" pname="c" oct="5" accid.ges="n"/>
+                      <note xml:id="d1e17128" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e17149" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e17168" pname="c" oct="5" accid.ges="n" />
                     </chord>
                   </beam>
                 </layer>
@@ -2978,24 +2747,23 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d3220e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
-                      <note xml:id="d1e17187" pname="e" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e17209" pname="c" oct="6"/>
+                      <note xml:id="d1e17187" pname="e" oct="5" accid.ges="f" />
+                      <note xml:id="d1e17209" pname="c" oct="6" />
                     </chord>
-                    <note xml:id="d1e17226" pname="a" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e17226" pname="a" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d3227e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e17248" pname="e" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e17268" pname="b" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e17248" pname="e" oct="5" accid.ges="f" />
+                      <note xml:id="d1e17268" pname="b" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                   <chord xml:id="d3233e1" dur="8" dur.ppq="2" stem.dir="down">
-                    <note xml:id="d1e17287" pname="e" oct="5" accid.ges="f"/>
-                    <note xml:id="d1e17305" pname="a" oct="5" accid.ges="f"/>
+                    <note xml:id="d1e17287" pname="e" oct="5" accid.ges="f" />
+                    <note xml:id="d1e17305" pname="a" oct="5" accid.ges="f" />
                   </chord>
-                  <rest xml:id="d1e17324" dur="16" dur.ppq="1"/>
-                  <chord xml:id="d3241e1" dur="16" dur.ppq="1" stem.dir="down" tie="i">
-                    <note xml:id="d1e17334" pname="a" oct="4" accid.ges="f"/>
-                    <note xml:id="d1e17355" pname="a" oct="5" accid.ges="f"/>
+                  <rest xml:id="d1e17324" dur="16" dur.ppq="1" />
+                  <chord xml:id="d3241e1" dur="16" dur.ppq="1" stem.dir="down">
+                    <note xml:id="d1e17334" pname="a" oct="4" accid.ges="f" />
+                    <note xml:id="d1e17355" pname="a" oct="5" accid.ges="f" />
                   </chord>
                 </layer>
               </staff>
@@ -3003,54 +2771,52 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d3247e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e17381" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e17401" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e17420" pname="c" oct="5"/>
+                      <note xml:id="d1e17381" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e17401" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e17420" pname="c" oct="5" />
                     </chord>
                     <chord xml:id="d3254e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e17437" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e17457" pname="g" oct="4"/>
-                      <note xml:id="d1e17474" pname="d" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e17437" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e17457" pname="g" oct="4" />
+                      <note xml:id="d1e17474" pname="d" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                   <chord xml:id="d3261e1" dur="8" dur.ppq="2" stem.dir="down">
-                    <note xml:id="d1e17493" pname="a" oct="4" accid.ges="f"/>
-                    <note xml:id="d1e17511" pname="c" oct="5"/>
+                    <note xml:id="d1e17493" pname="a" oct="4" accid.ges="f" />
+                    <note xml:id="d1e17511" pname="c" oct="5" />
                   </chord>
-                  <rest xml:id="d1e17528" dur="8" dur.ppq="2"/>
+                  <rest xml:id="d1e17528" dur="8" dur.ppq="2" />
+                  <clef line="4" shape="F" />
                 </layer>
               </staff>
-              <tie tstamp="2.75" startid="#d1e17334" curvedir="above" tstamp2="1m+1"
-                endid="#d1e17546" staff="1"/>
-              <tie tstamp="2.75" startid="#d1e17355" curvedir="above" tstamp2="1m+1"
-                endid="#d1e17569" staff="1"/>
+              <tie tstamp="2.75" startid="#d1e17334" curvedir="below" tstamp2="1m+1" endid="#d1e17546" staff="1" />
+              <tie tstamp="2.75" startid="#d1e17355" curvedir="above" tstamp2="1m+1" endid="#d1e17569" staff="1" />
             </measure>
-            <staffDef n="2" clef.line="4" clef.shape="F"/>
             <measure n="48" xml:id="d1e17538" width="59.64">
               <staff n="1">
                 <layer n="1">
                   <beam>
-                    <chord xml:id="d3294e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e17546" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e17569" pname="a" oct="5" accid.ges="f"/>
+                    <chord xml:id="d3294e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
+                      <note xml:id="d1e17546" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e17569" pname="a" oct="5" accid.ges="f" />
                     </chord>
                     <chord xml:id="d3300e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e17591" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e17611" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e17591" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e17611" pname="a" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d3306e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e17630" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e17650" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e17630" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e17650" pname="a" oct="5" accid.ges="f" />
                     </chord>
                     <chord xml:id="d3312e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e17669" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e17691" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e17669" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e17691" pname="a" oct="5" accid.ges="f" />
                     </chord>
                     <chord xml:id="d3318e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
-                      <note xml:id="d1e17710" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e17732" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e17710" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e17732" pname="a" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -3059,34 +2825,34 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d3324e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e17755" pname="d" accid="n" oct="3">
-                        <accid accid="n"/>
+                      <note xml:id="d1e17755" pname="d" accid.ges="n" oct="3">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e17775" pname="f" oct="3"/>
-                      <note xml:id="d1e17792" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e17811" pname="b" accid="n" oct="3">
-                        <accid accid="n"/>
+                      <note xml:id="d1e17775" pname="f" oct="3" />
+                      <note xml:id="d1e17792" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e17811" pname="b" accid.ges="n" oct="3">
+                        <accid accid="n" />
                       </note>
                     </chord>
                     <chord xml:id="d3332e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e17830" pname="d" oct="3" accid.ges="n"/>
-                      <note xml:id="d1e17848" pname="f" oct="3"/>
-                      <note xml:id="d1e17865" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e17884" pname="b" oct="3" accid.ges="n"/>
+                      <note xml:id="d1e17830" pname="d" oct="3" accid.ges="n" />
+                      <note xml:id="d1e17848" pname="f" oct="3" />
+                      <note xml:id="d1e17865" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e17884" pname="b" oct="3" accid.ges="n" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d3340e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e17901" pname="d" oct="3" accid.ges="n"/>
-                      <note xml:id="d1e17919" pname="f" oct="3"/>
-                      <note xml:id="d1e17937" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e17956" pname="b" oct="3" accid.ges="n"/>
+                      <note xml:id="d1e17901" pname="d" oct="3" accid.ges="n" />
+                      <note xml:id="d1e17919" pname="f" oct="3" />
+                      <note xml:id="d1e17937" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e17956" pname="b" oct="3" accid.ges="n" />
                     </chord>
                     <chord xml:id="d3348e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e17973" pname="d" oct="3" accid.ges="n"/>
-                      <note xml:id="d1e17991" pname="f" oct="3"/>
-                      <note xml:id="d1e18008" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e18027" pname="b" oct="3" accid.ges="n"/>
+                      <note xml:id="d1e17973" pname="d" oct="3" accid.ges="n" />
+                      <note xml:id="d1e17991" pname="f" oct="3" />
+                      <note xml:id="d1e18008" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e18027" pname="b" oct="3" accid.ges="n" />
                     </chord>
                   </beam>
                 </layer>
@@ -3097,30 +2863,27 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d3379e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
-                      <note xml:id="d1e18046" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e18068" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e18046" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e18068" pname="a" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e18087" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e18087" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d3386e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e18109" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e18131" pname="f" oct="5"/>
+                      <note xml:id="d1e18109" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e18131" pname="f" oct="5" />
                     </chord>
-                    <note xml:id="d1e18148" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e18148" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e18168" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e18168" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d3394e1" dur="8" dur.ppq="2" stem.dir="down" beam="m1">
-                      <note xml:id="d1e18190" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e18210" pname="f" oct="5"/>
+                      <note xml:id="d1e18190" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e18210" pname="f" oct="5" />
                     </chord>
-                    <chord xml:id="d3400e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e18227" pname="f" accid="f" oct="4">
-                        <accid accid="f"/>
+                    <chord xml:id="d3400e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e18227" pname="f" accid.ges="f" oct="4">
+                        <accid accid="f" />
                       </note>
-                      <note xml:id="d1e18254" pname="a" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e18254" pname="a" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -3129,75 +2892,62 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d3406e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e18280" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e18300" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e18319" pname="c" oct="4"/>
+                      <note xml:id="d1e18280" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e18300" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e18319" pname="c" oct="4" />
                     </chord>
                     <chord xml:id="d3413e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e18336" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e18356" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e18375" pname="c" oct="4"/>
+                      <note xml:id="d1e18336" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e18356" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e18375" pname="c" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d3420e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e18392" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e18412" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e18431" pname="c" oct="4"/>
+                      <note xml:id="d1e18392" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e18412" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e18431" pname="c" oct="4" />
                     </chord>
                     <chord xml:id="d3427e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e18448" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e18469" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e18488" pname="c" oct="4"/>
+                      <note xml:id="d1e18448" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e18469" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e18488" pname="c" oct="4" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="2.75" startid="#d1e18227" curvedir="above" tstamp2="1m+1"
-                endid="#d1e18519" staff="1"/>
-              <tie tstamp="2.75" startid="#d1e18254" curvedir="above" tstamp2="1m+1"
-                endid="#d1e18544" staff="1"/>
+              <tie tstamp="2.75" startid="#d1e18227" curvedir="below" tstamp2="1m+1" endid="#d1e18519" staff="1" />
+              <tie tstamp="2.75" startid="#d1e18254" curvedir="above" tstamp2="1m+1" endid="#d1e18544" staff="1" />
             </measure>
-            <sb/>
-            <scoreDef system.leftmar="4.2" system.rightmar="0" spacing.system="30">
-              <staffGrp>
-                <staffGrp symbol="brace">
-                  <staffDef n="2" spacing="13"/>
-                </staffGrp>
-              </staffGrp>
-            </scoreDef>
+            <sb />
             <measure n="50" xml:id="d1e18505" width="79.676">
               <staff n="1">
                 <layer n="1">
                   <beam>
-                    <chord xml:id="d3467e1" dur="16" dur.ppq="1" stem.dir="up" beam="i1" tie="t">
-                      <note xml:id="d1e18519" pname="f" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e18544" pname="a" oct="4" accid.ges="f"/>
+                    <chord xml:id="d3467e1" dur="16" dur.ppq="1" stem.dir="up" beam="i1">
+                      <note xml:id="d1e18519" pname="f" oct="4" accid.ges="f" />
+                      <note xml:id="d1e18544" pname="a" oct="4" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e18566" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e18566" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="up" accid.ges="f" />
                     <chord xml:id="d3474e1" dur="16" dur.ppq="1" stem.dir="up" beam="m1">
-                      <note xml:id="d1e18588" pname="f" accid="f" oct="4">
-                        <accid accid="f"/>
+                      <note xml:id="d1e18588" pname="f" accid.ges="f" oct="4">
+                        <accid accid="f" />
                       </note>
-                      <note xml:id="d1e18612" pname="c" accid="f" oct="5">
-                        <accid accid="f"/>
+                      <note xml:id="d1e18612" pname="c" accid.ges="f" oct="5">
+                        <accid accid="f" />
                       </note>
                     </chord>
-                    <note xml:id="d1e18633" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e18633" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1" stem.dir="up" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e18655" pname="b" oct="4" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e18655" pname="b" oct="4" dur="16" dur.ppq="1" beam="i1" stem.dir="up" accid.ges="f" />
                     <chord xml:id="d3482e1" dur="8" dur.ppq="2" stem.dir="up" beam="m1">
-                      <note xml:id="d1e18677" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e18697" pname="c" accid="n" oct="5">
-                        <accid accid="n"/>
+                      <note xml:id="d1e18677" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e18697" pname="c" accid.ges="n" oct="5">
+                        <accid accid="n" />
                       </note>
                     </chord>
-                    <note xml:id="d1e18716" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e18716" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1" stem.dir="up" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
@@ -3205,60 +2955,59 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d3489e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e18742" pname="f" accid="f" oct="3">
-                        <accid accid="f"/>
+                      <note xml:id="d1e18742" pname="f" accid.ges="f" oct="3">
+                        <accid accid="f" />
                       </note>
-                      <note xml:id="d1e18764" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e18783" pname="c" accid="f" oct="4">
-                        <accid accid="f"/>
+                      <note xml:id="d1e18764" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e18783" pname="c" accid.ges="f" oct="4">
+                        <accid accid="f" />
                       </note>
                     </chord>
                     <chord xml:id="d3496e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e18804" pname="f" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e18824" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e18843" pname="c" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e18804" pname="f" oct="3" accid.ges="f" />
+                      <note xml:id="d1e18824" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e18843" pname="c" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d3503e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e18862" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e18882" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e18901" pname="c" accid="n" oct="4">
-                        <accid accid="n"/>
+                      <note xml:id="d1e18862" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e18882" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e18901" pname="c" accid.ges="n" oct="4">
+                        <accid accid="n" />
                       </note>
                     </chord>
                     <chord xml:id="d3510e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e18920" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e18941" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e18960" pname="c" oct="4" accid.ges="n"/>
+                      <note xml:id="d1e18920" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e18941" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e18960" pname="c" oct="4" accid.ges="n" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
             </measure>
-            <measure n="51" xml:id="d1e18978" right="rptstart" width="54">
+            <measure n="51" xml:id="d1e18978" right="dbl" width="54">
               <staff n="1">
                 <layer n="1">
                   <beam>
                     <chord xml:id="d3540e1" dur="16" dur.ppq="1" stem.dir="up" beam="i1">
-                      <note xml:id="d1e18980" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e19002" pname="c" oct="5"/>
+                      <note xml:id="d1e18980" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e19002" pname="c" oct="5" />
                     </chord>
-                    <note xml:id="d1e19019" pname="a" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e19019" pname="a" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="up" accid.ges="f" />
                     <chord xml:id="d3547e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e19041" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e19061" pname="b" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e19041" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e19061" pname="b" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d3553e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e19080" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e19100" pname="a" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e19080" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e19100" pname="a" oct="4" accid.ges="f" />
                     </chord>
                     <chord xml:id="d3559e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e19119" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e19139" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e19119" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e19139" pname="a" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -3267,21 +3016,21 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d3565e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e19161" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e19182" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e19201" pname="c" oct="4"/>
+                      <note xml:id="d1e19161" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e19182" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e19201" pname="c" oct="4" />
                     </chord>
                     <chord xml:id="d3572e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e19218" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e19238" pname="g" oct="3"/>
-                      <note xml:id="d1e19255" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e19218" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e19238" pname="g" oct="3" />
+                      <note xml:id="d1e19255" pname="d" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <chord xml:id="d3579e1" dur="8" dur.ppq="2" stem.dir="down">
-                    <note xml:id="d1e19274" pname="a" oct="3" accid.ges="f"/>
-                    <note xml:id="d1e19292" pname="c" oct="4"/>
+                    <note xml:id="d1e19274" pname="a" oct="3" accid.ges="f" />
+                    <note xml:id="d1e19292" pname="c" oct="4" />
                   </chord>
-                  <rest xml:id="d1e19309" dur="8" dur.ppq="2"/>
+                  <rest xml:id="d1e19309" dur="8" dur.ppq="2" />
                 </layer>
               </staff>
             </measure>
@@ -3290,8 +3039,8 @@
             <scoreDef key.sig="5f" key.mode="major">
               <staffGrp>
                 <staffGrp symbol="brace">
-                  <staffDef n="1" key.sig="5f"/>
-                  <staffDef n="2" key.sig="5f"/>
+                  <staffDef n="1" key.sig="5f" />
+                  <staffDef n="2" key.sig="5f" />
                 </staffGrp>
               </staffGrp>
             </scoreDef>
@@ -3300,31 +3049,30 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d3608e1" dur="8" dots="1" dur.ppq="3" stem.dir="down" beam="i1">
-                      <note xml:id="d1e19331" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e19352" pname="c" oct="5"/>
-                      <note xml:id="d1e19370" pname="e" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e19390" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e19331" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e19352" pname="c" oct="5" />
+                      <note xml:id="d1e19370" pname="e" oct="5" accid.ges="f" />
+                      <note xml:id="d1e19390" pname="a" oct="5" accid.ges="f" />
                     </chord>
-                    <chord xml:id="d3616e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e19416" pname="b" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e19441" pname="c" oct="5"/>
-                      <note xml:id="d1e19461" pname="e" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e19483" pname="a" oct="5" accid.ges="f"/>
+                    <chord xml:id="d3616e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e19416" pname="b" oct="4" accid.ges="f" />
+                      <note xml:id="d1e19441" pname="c" oct="5" />
+                      <note xml:id="d1e19461" pname="e" oct="5" accid.ges="f" />
+                      <note xml:id="d1e19483" pname="a" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
-                    <chord xml:id="d3624e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e19506" pname="b" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e19531" pname="c" oct="5"/>
-                      <note xml:id="d1e19551" pname="e" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e19573" pname="a" oct="5" accid.ges="f"/>
+                    <chord xml:id="d3624e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
+                      <note xml:id="d1e19506" pname="b" oct="4" accid.ges="f" />
+                      <note xml:id="d1e19531" pname="c" oct="5" />
+                      <note xml:id="d1e19551" pname="e" oct="5" accid.ges="f" />
+                      <note xml:id="d1e19573" pname="a" oct="5" accid.ges="f" />
                     </chord>
                     <chord xml:id="d3632e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e19595" pname="c" oct="5"/>
-                      <note xml:id="d1e19615" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e19595" pname="c" oct="5" />
+                      <note xml:id="d1e19615" pname="e" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e19634" pname="b" oct="4" dur="8" dur.ppq="2" beam="t1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e19634" pname="b" oct="4" dur="8" dur.ppq="2" beam="t1" stem.dir="down" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
@@ -3332,71 +3080,66 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d3639e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e19657" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e19677" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e19657" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e19677" pname="e" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d3645e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e19696" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e19717" pname="c" oct="4"/>
-                      <note xml:id="d1e19734" pname="g" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e19696" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e19717" pname="c" oct="4" />
+                      <note xml:id="d1e19734" pname="g" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d3652e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e19753" pname="g" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e19773" pname="g" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e19753" pname="g" oct="2" accid.ges="f" />
+                      <note xml:id="d1e19773" pname="g" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d3658e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e19792" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e19812" pname="c" oct="4"/>
-                      <note xml:id="d1e19829" pname="g" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e19792" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e19812" pname="c" oct="4" />
+                      <note xml:id="d1e19829" pname="g" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <dir tstamp="1.75" place="above" staff="1" label="words">TRIO</dir>
-              <tie tstamp="1.75" startid="#d1e19416" curvedir="above" tstamp2="0m+2"
-                endid="#d1e19506" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e19441" curvedir="above" tstamp2="0m+2"
-                endid="#d1e19531" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e19461" curvedir="above" tstamp2="0m+2"
-                endid="#d1e19551" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e19483" curvedir="above" tstamp2="0m+2"
-                endid="#d1e19573" staff="1"/>
+              <dir tstamp="1.00" place="above" staff="1" label="words">TRIO</dir>
+              <tie tstamp="1.75" startid="#d1e19416" curvedir="above" tstamp2="0m+2" endid="#d1e19506" staff="1" />
+              <tie tstamp="1.75" startid="#d1e19441" curvedir="above" tstamp2="0m+2" endid="#d1e19531" staff="1" />
+              <tie tstamp="1.75" startid="#d1e19461" curvedir="above" tstamp2="0m+2" endid="#d1e19551" staff="1" />
+              <tie tstamp="1.75" startid="#d1e19483" curvedir="above" tstamp2="0m+2" endid="#d1e19573" staff="1" />
             </measure>
             <measure n="53" xml:id="d1e19848" width="59.796">
               <staff n="1">
                 <layer n="1">
                   <beam>
                     <chord xml:id="d3707e1" dur="8" dots="1" dur.ppq="3" stem.dir="down" beam="i1">
-                      <note xml:id="d1e19850" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e19871" pname="c" oct="5"/>
-                      <note xml:id="d1e19889" pname="e" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e19909" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e19850" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e19871" pname="c" oct="5" />
+                      <note xml:id="d1e19889" pname="e" oct="5" accid.ges="f" />
+                      <note xml:id="d1e19909" pname="a" oct="5" accid.ges="f" />
                     </chord>
-                    <chord xml:id="d3715e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e19929" pname="b" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e19954" pname="c" oct="5"/>
-                      <note xml:id="d1e19974" pname="e" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e19996" pname="a" oct="5" accid.ges="f"/>
+                    <chord xml:id="d3715e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e19929" pname="b" oct="4" accid.ges="f" />
+                      <note xml:id="d1e19954" pname="c" oct="5" />
+                      <note xml:id="d1e19974" pname="e" oct="5" accid.ges="f" />
+                      <note xml:id="d1e19996" pname="a" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
-                    <chord xml:id="d3723e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e20018" pname="b" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e20043" pname="c" oct="5"/>
-                      <note xml:id="d1e20063" pname="e" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e20086" pname="a" oct="5" accid.ges="f"/>
+                    <chord xml:id="d3723e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
+                      <note xml:id="d1e20018" pname="b" oct="4" accid.ges="f" />
+                      <note xml:id="d1e20043" pname="c" oct="5" />
+                      <note xml:id="d1e20063" pname="e" oct="5" accid.ges="f" />
+                      <note xml:id="d1e20086" pname="a" oct="5" accid.ges="f" />
                     </chord>
                     <chord xml:id="d3731e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e20108" pname="c" oct="5"/>
-                      <note xml:id="d1e20128" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e20108" pname="c" oct="5" />
+                      <note xml:id="d1e20128" pname="e" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e20147" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e20147" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d3738e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
-                      <note xml:id="d1e20169" pname="c" oct="5"/>
-                      <note xml:id="d1e20189" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e20169" pname="c" oct="5" />
+                      <note xml:id="d1e20189" pname="e" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -3405,66 +3148,47 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d3744e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e20211" pname="f" oct="2"/>
-                      <note xml:id="d1e20229" pname="f" oct="3"/>
+                      <note xml:id="d1e20211" pname="f" oct="2" />
+                      <note xml:id="d1e20229" pname="f" oct="3" />
                     </chord>
                     <chord xml:id="d3750e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e20246" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e20266" pname="c" oct="4"/>
-                      <note xml:id="d1e20284" pname="g" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e20246" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e20266" pname="c" oct="4" />
+                      <note xml:id="d1e20284" pname="g" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d3757e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e20303" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e20323" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e20303" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e20323" pname="e" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d3763e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e20342" pname="c" oct="2"/>
-                      <note xml:id="d1e20360" pname="c" oct="3"/>
+                      <note xml:id="d1e20342" pname="c" oct="2" />
+                      <note xml:id="d1e20360" pname="c" oct="3" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="1.75" startid="#d1e19929" curvedir="above" tstamp2="0m+2"
-                endid="#d1e20018" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e19954" curvedir="above" tstamp2="0m+2"
-                endid="#d1e20043" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e19974" curvedir="above" tstamp2="0m+2"
-                endid="#d1e20063" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e19996" curvedir="above" tstamp2="0m+2"
-                endid="#d1e20086" staff="1"/>
+              <tie tstamp="1.75" startid="#d1e19929" curvedir="above" tstamp2="0m+2" endid="#d1e20018" staff="1" />
+              <tie tstamp="1.75" startid="#d1e19954" curvedir="above" tstamp2="0m+2" endid="#d1e20043" staff="1" />
+              <tie tstamp="1.75" startid="#d1e19974" curvedir="above" tstamp2="0m+2" endid="#d1e20063" staff="1" />
+              <tie tstamp="1.75" startid="#d1e19996" curvedir="above" tstamp2="0m+2" endid="#d1e20086" staff="1" />
             </measure>
-            <sb/>
-            <scoreDef system.leftmar="4.2" system.rightmar="0" spacing.system="30">
-              <staffGrp>
-                <staffGrp symbol="brace">
-                  <staffDef n="2" spacing="13"/>
-                </staffGrp>
-              </staffGrp>
-            </scoreDef>
+            <sb />
             <measure n="54" xml:id="d1e20377" width="77.494">
               <staff n="1">
                 <layer n="1">
                   <beam>
-                    <note xml:id="d1e20391" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e20413" pname="d" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e20435" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e20457" pname="d" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e20391" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e20413" pname="d" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e20435" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e20457" pname="d" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e20479" pname="f" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down"/>
-                    <note xml:id="d1e20499" pname="a" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e20521" pname="d" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e20543" pname="f" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e20479" pname="f" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" />
+                    <note xml:id="d1e20499" pname="a" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e20521" pname="d" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e20543" pname="f" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                 </layer>
               </staff>
@@ -3472,24 +3196,24 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d3818e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e20566" pname="d" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e20587" pname="d" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e20566" pname="d" oct="2" accid.ges="f" />
+                      <note xml:id="d1e20587" pname="d" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d3824e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e20606" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e20626" pname="d" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e20645" pname="f" oct="4"/>
+                      <note xml:id="d1e20606" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e20626" pname="d" oct="4" accid.ges="f" />
+                      <note xml:id="d1e20645" pname="f" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d3831e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e20662" pname="a" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e20682" pname="a" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e20662" pname="a" oct="2" accid.ges="f" />
+                      <note xml:id="d1e20682" pname="a" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d3837e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e20701" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e20721" pname="d" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e20740" pname="f" oct="4"/>
+                      <note xml:id="d1e20701" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e20721" pname="d" oct="4" accid.ges="f" />
+                      <note xml:id="d1e20740" pname="f" oct="4" />
                     </chord>
                   </beam>
                 </layer>
@@ -3499,24 +3223,16 @@
               <staff n="1">
                 <layer n="1">
                   <beam>
-                    <note xml:id="d1e20759" pname="b" oct="4" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e20781" pname="d" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e20803" pname="f" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down"/>
-                    <note xml:id="d1e20823" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1" tie="i"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e20759" pname="b" oct="4" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e20781" pname="d" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e20803" pname="f" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" />
+                    <note xml:id="d1e20823" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1" stem.dir="down" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e20848" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1" tie="t"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e20873" pname="f" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down"/>
-                    <note xml:id="d1e20893" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e20915" pname="f" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e20848" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e20873" pname="f" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" />
+                    <note xml:id="d1e20893" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e20915" pname="f" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                 </layer>
               </staff>
@@ -3524,64 +3240,62 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d3875e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e20938" pname="f" oct="2"/>
-                      <note xml:id="d1e20956" pname="f" oct="3"/>
+                      <note xml:id="d1e20938" pname="f" oct="2" />
+                      <note xml:id="d1e20956" pname="f" oct="3" />
                     </chord>
                     <chord xml:id="d3881e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e20974" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e20994" pname="d" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e21013" pname="f" oct="4"/>
+                      <note xml:id="d1e20974" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e20994" pname="d" oct="4" accid.ges="f" />
+                      <note xml:id="d1e21013" pname="f" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d3888e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e21030" pname="d" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e21050" pname="d" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e21030" pname="d" oct="2" accid.ges="f" />
+                      <note xml:id="d1e21050" pname="d" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d3894e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e21069" pname="d" accid="n" oct="2">
-                        <accid accid="n"/>
+                      <note xml:id="d1e21069" pname="d" accid.ges="n" oct="2">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e21089" pname="d" accid="n" oct="3">
-                        <accid accid="n"/>
+                      <note xml:id="d1e21089" pname="d" accid.ges="n" oct="3">
+                        <accid accid="n" />
                       </note>
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="1.75" startid="#d1e20823" curvedir="above" tstamp2="0m+2"
-                endid="#d1e20848" staff="1"/>
+              <tie tstamp="1.75" startid="#d1e20823" curvedir="above" tstamp2="0m+2" endid="#d1e20848" staff="1" />
             </measure>
             <measure n="56" xml:id="d1e21108" width="59.364">
               <staff n="1">
                 <layer n="1">
                   <beam>
                     <chord xml:id="d3927e1" dur="8" dots="1" dur.ppq="3" stem.dir="down" beam="i1">
-                      <note xml:id="d1e21110" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e21131" pname="c" oct="5"/>
-                      <note xml:id="d1e21149" pname="e" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e21169" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e21110" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e21131" pname="c" oct="5" />
+                      <note xml:id="d1e21149" pname="e" oct="5" accid.ges="f" />
+                      <note xml:id="d1e21169" pname="a" oct="5" accid.ges="f" />
                     </chord>
-                    <chord xml:id="d3935e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e21189" pname="b" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e21214" pname="c" oct="5"/>
-                      <note xml:id="d1e21234" pname="e" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e21256" pname="a" oct="5" accid.ges="f"/>
+                    <chord xml:id="d3935e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e21189" pname="b" oct="4" accid.ges="f" />
+                      <note xml:id="d1e21214" pname="c" oct="5" />
+                      <note xml:id="d1e21234" pname="e" oct="5" accid.ges="f" />
+                      <note xml:id="d1e21256" pname="a" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
-                    <chord xml:id="d3943e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e21278" pname="b" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e21303" pname="c" oct="5"/>
-                      <note xml:id="d1e21323" pname="e" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e21346" pname="a" oct="5" accid.ges="f"/>
+                    <chord xml:id="d3943e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
+                      <note xml:id="d1e21278" pname="b" oct="4" accid.ges="f" />
+                      <note xml:id="d1e21303" pname="c" oct="5" />
+                      <note xml:id="d1e21323" pname="e" oct="5" accid.ges="f" />
+                      <note xml:id="d1e21346" pname="a" oct="5" accid.ges="f" />
                     </chord>
                     <chord xml:id="d3951e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e21368" pname="c" oct="5"/>
-                      <note xml:id="d1e21388" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e21368" pname="c" oct="5" />
+                      <note xml:id="d1e21388" pname="e" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e21407" pname="b" oct="4" dur="8" dur.ppq="2" beam="t1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e21407" pname="b" oct="4" dur="8" dur.ppq="2" beam="t1" stem.dir="down" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
@@ -3589,70 +3303,65 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d3958e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e21430" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e21450" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e21430" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e21450" pname="e" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d3964e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e21469" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e21489" pname="c" oct="4"/>
-                      <note xml:id="d1e21506" pname="g" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e21469" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e21489" pname="c" oct="4" />
+                      <note xml:id="d1e21506" pname="g" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d3971e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e21525" pname="g" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e21546" pname="g" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e21525" pname="g" oct="2" accid.ges="f" />
+                      <note xml:id="d1e21546" pname="g" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d3977e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e21565" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e21585" pname="c" oct="4"/>
-                      <note xml:id="d1e21602" pname="g" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e21565" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e21585" pname="c" oct="4" />
+                      <note xml:id="d1e21602" pname="g" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="1.75" startid="#d1e21189" curvedir="above" tstamp2="0m+2"
-                endid="#d1e21278" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e21214" curvedir="above" tstamp2="0m+2"
-                endid="#d1e21303" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e21234" curvedir="above" tstamp2="0m+2"
-                endid="#d1e21323" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e21256" curvedir="above" tstamp2="0m+2"
-                endid="#d1e21346" staff="1"/>
+              <tie tstamp="1.75" startid="#d1e21189" curvedir="above" tstamp2="0m+2" endid="#d1e21278" staff="1" />
+              <tie tstamp="1.75" startid="#d1e21214" curvedir="above" tstamp2="0m+2" endid="#d1e21303" staff="1" />
+              <tie tstamp="1.75" startid="#d1e21234" curvedir="above" tstamp2="0m+2" endid="#d1e21323" staff="1" />
+              <tie tstamp="1.75" startid="#d1e21256" curvedir="above" tstamp2="0m+2" endid="#d1e21346" staff="1" />
             </measure>
             <measure n="57" xml:id="d1e21621" width="62.498">
               <staff n="1">
                 <layer n="1">
                   <beam>
                     <chord xml:id="d4023e1" dur="8" dots="1" dur.ppq="3" stem.dir="down" beam="i1">
-                      <note xml:id="d1e21623" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e21644" pname="c" oct="5"/>
-                      <note xml:id="d1e21662" pname="e" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e21682" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e21623" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e21644" pname="c" oct="5" />
+                      <note xml:id="d1e21662" pname="e" oct="5" accid.ges="f" />
+                      <note xml:id="d1e21682" pname="a" oct="5" accid.ges="f" />
                     </chord>
-                    <chord xml:id="d4031e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e21702" pname="b" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e21727" pname="c" oct="5"/>
-                      <note xml:id="d1e21747" pname="e" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e21769" pname="a" oct="5" accid.ges="f"/>
+                    <chord xml:id="d4031e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e21702" pname="b" oct="4" accid.ges="f" />
+                      <note xml:id="d1e21727" pname="c" oct="5" />
+                      <note xml:id="d1e21747" pname="e" oct="5" accid.ges="f" />
+                      <note xml:id="d1e21769" pname="a" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
-                    <chord xml:id="d4039e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e21791" pname="b" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e21816" pname="c" oct="5"/>
-                      <note xml:id="d1e21836" pname="e" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e21859" pname="a" oct="5" accid.ges="f"/>
+                    <chord xml:id="d4039e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
+                      <note xml:id="d1e21791" pname="b" oct="4" accid.ges="f" />
+                      <note xml:id="d1e21816" pname="c" oct="5" />
+                      <note xml:id="d1e21836" pname="e" oct="5" accid.ges="f" />
+                      <note xml:id="d1e21859" pname="a" oct="5" accid.ges="f" />
                     </chord>
                     <chord xml:id="d4047e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e21881" pname="c" oct="5"/>
-                      <note xml:id="d1e21901" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e21881" pname="c" oct="5" />
+                      <note xml:id="d1e21901" pname="e" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e21920" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e21920" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d4054e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
-                      <note xml:id="d1e21942" pname="c" oct="5"/>
-                      <note xml:id="d1e21962" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e21942" pname="c" oct="5" />
+                      <note xml:id="d1e21962" pname="e" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -3661,66 +3370,47 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d4060e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e21984" pname="f" oct="2"/>
-                      <note xml:id="d1e22002" pname="f" oct="3"/>
+                      <note xml:id="d1e21984" pname="f" oct="2" />
+                      <note xml:id="d1e22002" pname="f" oct="3" />
                     </chord>
                     <chord xml:id="d4066e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e22019" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e22039" pname="c" oct="4"/>
-                      <note xml:id="d1e22057" pname="g" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e22019" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e22039" pname="c" oct="4" />
+                      <note xml:id="d1e22057" pname="g" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d4073e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e22076" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e22096" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e22076" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e22096" pname="e" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d4079e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e22115" pname="c" oct="2"/>
-                      <note xml:id="d1e22133" pname="c" oct="3"/>
+                      <note xml:id="d1e22115" pname="c" oct="2" />
+                      <note xml:id="d1e22133" pname="c" oct="3" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="1.75" startid="#d1e21702" curvedir="above" tstamp2="0m+2"
-                endid="#d1e21791" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e21727" curvedir="above" tstamp2="0m+2"
-                endid="#d1e21816" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e21747" curvedir="above" tstamp2="0m+2"
-                endid="#d1e21836" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e21769" curvedir="above" tstamp2="0m+2"
-                endid="#d1e21859" staff="1"/>
+              <tie tstamp="1.75" startid="#d1e21702" curvedir="above" tstamp2="0m+2" endid="#d1e21791" staff="1" />
+              <tie tstamp="1.75" startid="#d1e21727" curvedir="above" tstamp2="0m+2" endid="#d1e21816" staff="1" />
+              <tie tstamp="1.75" startid="#d1e21747" curvedir="above" tstamp2="0m+2" endid="#d1e21836" staff="1" />
+              <tie tstamp="1.75" startid="#d1e21769" curvedir="above" tstamp2="0m+2" endid="#d1e21859" staff="1" />
             </measure>
-            <sb/>
-            <scoreDef system.leftmar="4.2" system.rightmar="0" spacing.system="30">
-              <staffGrp>
-                <staffGrp symbol="brace">
-                  <staffDef n="2" spacing="13"/>
-                </staffGrp>
-              </staffGrp>
-            </scoreDef>
+            <sb />
             <measure n="58" xml:id="d1e22150" width="75.552">
               <staff n="1">
                 <layer n="1">
                   <beam>
-                    <note xml:id="d1e22164" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e22186" pname="d" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e22208" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e22230" pname="d" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e22164" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e22186" pname="d" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e22208" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e22230" pname="d" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e22252" pname="f" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down"/>
-                    <note xml:id="d1e22272" pname="a" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e22294" pname="d" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e22316" pname="f" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e22252" pname="f" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" />
+                    <note xml:id="d1e22272" pname="a" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e22294" pname="d" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e22316" pname="f" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                 </layer>
               </staff>
@@ -3728,24 +3418,24 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d4134e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e22339" pname="d" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e22360" pname="d" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e22339" pname="d" oct="2" accid.ges="f" />
+                      <note xml:id="d1e22360" pname="d" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d4140e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e22379" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e22399" pname="d" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e22418" pname="f" oct="4"/>
+                      <note xml:id="d1e22379" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e22399" pname="d" oct="4" accid.ges="f" />
+                      <note xml:id="d1e22418" pname="f" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d4147e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e22435" pname="a" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e22455" pname="a" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e22435" pname="a" oct="2" accid.ges="f" />
+                      <note xml:id="d1e22455" pname="a" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d4153e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e22474" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e22494" pname="d" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e22513" pname="f" oct="4"/>
+                      <note xml:id="d1e22474" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e22494" pname="d" oct="4" accid.ges="f" />
+                      <note xml:id="d1e22513" pname="f" oct="4" />
                     </chord>
                   </beam>
                 </layer>
@@ -3755,27 +3445,20 @@
               <staff n="1">
                 <layer n="1">
                   <beam>
-                    <note xml:id="d1e22532" pname="b" oct="4" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e22554" pname="d" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e22576" pname="f" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down"/>
-                    <note xml:id="d1e22596" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1" tie="i"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e22532" pname="b" oct="4" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e22554" pname="d" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e22576" pname="f" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" />
+                    <note xml:id="d1e22596" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1" stem.dir="down" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e22621" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1" tie="t"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e22646" pname="f" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down"/>
-                    <note xml:id="d1e22666" pname="a" accid="n" oct="4" dur="16" dur.ppq="1"
-                      beam="m1" stem.dir="down">
-                      <accid accid="n"/>
+                    <note xml:id="d1e22621" pname="a" oct="4" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e22646" pname="f" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" />
+                    <note xml:id="d1e22666" pname="a" accid.ges="n" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="down">
+                      <accid accid="n" />
                     </note>
                     <chord xml:id="d4190e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
-                      <note xml:id="d1e22688" pname="e" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e22710" pname="f" oct="5"/>
+                      <note xml:id="d1e22688" pname="e" oct="5" accid.ges="f" />
+                      <note xml:id="d1e22710" pname="f" oct="5" />
                     </chord>
                   </beam>
                 </layer>
@@ -3784,62 +3467,60 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d4196e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e22730" pname="f" oct="2"/>
-                      <note xml:id="d1e22749" pname="f" oct="3"/>
+                      <note xml:id="d1e22730" pname="f" oct="2" />
+                      <note xml:id="d1e22749" pname="f" oct="3" />
                     </chord>
                     <chord xml:id="d4202e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e22766" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e22786" pname="d" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e22805" pname="f" oct="4"/>
+                      <note xml:id="d1e22766" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e22786" pname="d" oct="4" accid.ges="f" />
+                      <note xml:id="d1e22805" pname="f" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d4209e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e22822" pname="d" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e22842" pname="d" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e22822" pname="d" oct="2" accid.ges="f" />
+                      <note xml:id="d1e22842" pname="d" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d4215e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e22861" pname="c" oct="2"/>
-                      <note xml:id="d1e22879" pname="c" oct="3"/>
+                      <note xml:id="d1e22861" pname="c" oct="2" />
+                      <note xml:id="d1e22879" pname="c" oct="3" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="1.75" startid="#d1e22596" curvedir="above" tstamp2="0m+2"
-                endid="#d1e22621" staff="1"/>
+              <tie tstamp="1.75" startid="#d1e22596" curvedir="above" tstamp2="0m+2" endid="#d1e22621" staff="1" />
             </measure>
             <measure n="60" xml:id="d1e22896" width="59.004">
               <staff n="1">
                 <layer n="1">
                   <beam>
                     <chord xml:id="d4248e1" dur="8" dots="1" dur.ppq="3" stem.dir="down" beam="i1">
-                      <note xml:id="d1e22898" pname="b" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e22919" pname="d" accid="n" oct="5">
-                        <accid accid="n"/>
+                      <note xml:id="d1e22898" pname="b" oct="4" accid.ges="f" />
+                      <note xml:id="d1e22919" pname="d" accid.ges="n" oct="5">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e22939" pname="f" oct="5"/>
-                      <note xml:id="d1e22957" pname="b" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e22939" pname="f" oct="5" />
+                      <note xml:id="d1e22957" pname="b" oct="5" accid.ges="f" />
                     </chord>
-                    <chord xml:id="d4256e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e22977" pname="c" oct="5"/>
-                      <note xml:id="d1e23000" pname="d" oct="5" accid.ges="n"/>
-                      <note xml:id="d1e23020" pname="f" oct="5"/>
-                      <note xml:id="d1e23040" pname="b" oct="5" accid.ges="f"/>
+                    <chord xml:id="d4256e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e22977" pname="c" oct="5" />
+                      <note xml:id="d1e23000" pname="d" oct="5" accid.ges="n" />
+                      <note xml:id="d1e23020" pname="f" oct="5" />
+                      <note xml:id="d1e23040" pname="b" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
-                    <chord xml:id="d4264e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e23062" pname="c" oct="5"/>
-                      <note xml:id="d1e23085" pname="d" oct="5" accid.ges="n"/>
-                      <note xml:id="d1e23105" pname="f" oct="5"/>
-                      <note xml:id="d1e23126" pname="b" oct="5" accid.ges="f"/>
+                    <chord xml:id="d4264e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
+                      <note xml:id="d1e23062" pname="c" oct="5" />
+                      <note xml:id="d1e23085" pname="d" oct="5" accid.ges="n" />
+                      <note xml:id="d1e23105" pname="f" oct="5" />
+                      <note xml:id="d1e23126" pname="b" oct="5" accid.ges="f" />
                     </chord>
                     <chord xml:id="d4272e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e23148" pname="d" oct="5" accid.ges="n"/>
-                      <note xml:id="d1e23168" pname="f" oct="5"/>
+                      <note xml:id="d1e23148" pname="d" oct="5" accid.ges="n" />
+                      <note xml:id="d1e23168" pname="f" oct="5" />
                     </chord>
-                    <note xml:id="d1e23185" pname="c" oct="5" dur="8" dur.ppq="2" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e23185" pname="c" oct="5" dur="8" dur.ppq="2" beam="t1" stem.dir="down" />
                   </beam>
                 </layer>
               </staff>
@@ -3847,78 +3528,73 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d4279e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e23206" pname="b" oct="1" accid.ges="f"/>
-                      <note xml:id="d1e23226" pname="b" oct="2" accid.ges="f"/>
+                      <note xml:id="d1e23206" pname="b" oct="1" accid.ges="f" />
+                      <note xml:id="d1e23226" pname="b" oct="2" accid.ges="f" />
                     </chord>
                     <chord xml:id="d4285e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e23245" pname="b" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e23265" pname="d" accid="n" oct="4">
-                        <accid accid="n"/>
+                      <note xml:id="d1e23245" pname="b" oct="3" accid.ges="f" />
+                      <note xml:id="d1e23265" pname="d" accid.ges="n" oct="4">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e23284" pname="a" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e23284" pname="a" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d4292e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e23303" pname="d" accid="n" oct="2">
-                        <accid accid="n"/>
+                      <note xml:id="d1e23303" pname="d" accid.ges="n" oct="2">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e23324" pname="d" accid="n" oct="3">
-                        <accid accid="n"/>
+                      <note xml:id="d1e23324" pname="d" accid.ges="n" oct="3">
+                        <accid accid="n" />
                       </note>
                     </chord>
                     <chord xml:id="d4298e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e23343" pname="b" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e23363" pname="d" oct="4" accid.ges="n"/>
-                      <note xml:id="d1e23380" pname="a" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e23343" pname="b" oct="3" accid.ges="f" />
+                      <note xml:id="d1e23363" pname="d" oct="4" accid.ges="n" />
+                      <note xml:id="d1e23380" pname="a" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="1.75" startid="#d1e22977" curvedir="above" tstamp2="0m+2"
-                endid="#d1e23062" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e23000" curvedir="above" tstamp2="0m+2"
-                endid="#d1e23085" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e23020" curvedir="above" tstamp2="0m+2"
-                endid="#d1e23105" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e23040" curvedir="above" tstamp2="0m+2"
-                endid="#d1e23126" staff="1"/>
+              <tie tstamp="1.75" startid="#d1e22977" curvedir="above" tstamp2="0m+2" endid="#d1e23062" staff="1" />
+              <tie tstamp="1.75" startid="#d1e23000" curvedir="above" tstamp2="0m+2" endid="#d1e23085" staff="1" />
+              <tie tstamp="1.75" startid="#d1e23020" curvedir="above" tstamp2="0m+2" endid="#d1e23105" staff="1" />
+              <tie tstamp="1.75" startid="#d1e23040" curvedir="above" tstamp2="0m+2" endid="#d1e23126" staff="1" />
             </measure>
             <measure n="61" xml:id="d1e23399" width="62.136">
               <staff n="1">
                 <layer n="1">
                   <beam>
                     <chord xml:id="d4344e1" dur="8" dots="1" dur.ppq="3" stem.dir="down" beam="i1">
-                      <note xml:id="d1e23401" pname="b" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e23422" pname="d" accid="n" oct="5">
-                        <accid accid="n"/>
+                      <note xml:id="d1e23401" pname="b" oct="4" accid.ges="f" />
+                      <note xml:id="d1e23422" pname="d" accid.ges="n" oct="5">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e23442" pname="f" oct="5"/>
-                      <note xml:id="d1e23460" pname="b" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e23442" pname="f" oct="5" />
+                      <note xml:id="d1e23460" pname="b" oct="5" accid.ges="f" />
                     </chord>
-                    <chord xml:id="d4352e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e23480" pname="c" oct="5"/>
-                      <note xml:id="d1e23503" pname="d" oct="5" accid.ges="n"/>
-                      <note xml:id="d1e23523" pname="f" oct="5"/>
-                      <note xml:id="d1e23543" pname="b" oct="5" accid.ges="f"/>
+                    <chord xml:id="d4352e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e23480" pname="c" oct="5" />
+                      <note xml:id="d1e23503" pname="d" oct="5" accid.ges="n" />
+                      <note xml:id="d1e23523" pname="f" oct="5" />
+                      <note xml:id="d1e23543" pname="b" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
-                    <chord xml:id="d4360e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e23565" pname="c" oct="5"/>
-                      <note xml:id="d1e23588" pname="d" oct="5" accid.ges="n"/>
-                      <note xml:id="d1e23608" pname="f" oct="5"/>
-                      <note xml:id="d1e23629" pname="b" oct="5" accid.ges="f"/>
+                    <chord xml:id="d4360e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
+                      <note xml:id="d1e23565" pname="c" oct="5" />
+                      <note xml:id="d1e23588" pname="d" oct="5" accid.ges="n" />
+                      <note xml:id="d1e23608" pname="f" oct="5" />
+                      <note xml:id="d1e23629" pname="b" oct="5" accid.ges="f" />
                     </chord>
                     <chord xml:id="d4368e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e23651" pname="d" oct="5" accid.ges="n"/>
-                      <note xml:id="d1e23671" pname="f" oct="5"/>
+                      <note xml:id="d1e23651" pname="d" oct="5" accid.ges="n" />
+                      <note xml:id="d1e23671" pname="f" oct="5" />
                     </chord>
-                    <note xml:id="d1e23688" pname="c" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e23688" pname="c" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" />
                     <chord xml:id="d4375e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
-                      <note xml:id="d1e23708" pname="d" oct="5" accid.ges="n"/>
-                      <note xml:id="d1e23728" pname="f" oct="5"/>
+                      <note xml:id="d1e23708" pname="d" oct="5" accid.ges="n" />
+                      <note xml:id="d1e23728" pname="f" oct="5" />
                     </chord>
                   </beam>
                 </layer>
@@ -3927,70 +3603,55 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d4381e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e23748" pname="f" oct="2"/>
-                      <note xml:id="d1e23766" pname="f" oct="3"/>
+                      <note xml:id="d1e23748" pname="f" oct="2" />
+                      <note xml:id="d1e23766" pname="f" oct="3" />
                     </chord>
                     <chord xml:id="d4387e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e23783" pname="b" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e23803" pname="d" accid="n" oct="4">
-                        <accid accid="n"/>
+                      <note xml:id="d1e23783" pname="b" oct="3" accid.ges="f" />
+                      <note xml:id="d1e23803" pname="d" accid.ges="n" oct="4">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e23823" pname="a" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e23823" pname="a" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d4394e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e23842" pname="b" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e23862" pname="b" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e23842" pname="b" oct="2" accid.ges="f" />
+                      <note xml:id="d1e23862" pname="b" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d4400e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e23881" pname="b" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e23901" pname="d" oct="4" accid.ges="n"/>
-                      <note xml:id="d1e23918" pname="a" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e23881" pname="b" oct="3" accid.ges="f" />
+                      <note xml:id="d1e23901" pname="d" oct="4" accid.ges="n" />
+                      <note xml:id="d1e23918" pname="a" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="1.75" startid="#d1e23480" curvedir="above" tstamp2="0m+2"
-                endid="#d1e23565" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e23503" curvedir="above" tstamp2="0m+2"
-                endid="#d1e23588" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e23523" curvedir="above" tstamp2="0m+2"
-                endid="#d1e23608" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e23543" curvedir="above" tstamp2="0m+2"
-                endid="#d1e23629" staff="1"/>
+              <tie tstamp="1.75" startid="#d1e23480" curvedir="above" tstamp2="0m+2" endid="#d1e23565" staff="1" />
+              <tie tstamp="1.75" startid="#d1e23503" curvedir="above" tstamp2="0m+2" endid="#d1e23588" staff="1" />
+              <tie tstamp="1.75" startid="#d1e23523" curvedir="above" tstamp2="0m+2" endid="#d1e23608" staff="1" />
+              <tie tstamp="1.75" startid="#d1e23543" curvedir="above" tstamp2="0m+2" endid="#d1e23629" staff="1" />
             </measure>
-            <pb/>
-            <scoreDef system.leftmar="4.2" system.rightmar="0" system.topmar="14">
-              <staffGrp>
-                <staffGrp symbol="brace">
-                  <staffDef n="2" spacing="13"/>
-                </staffGrp>
-              </staffGrp>
-            </scoreDef>
+            <pb />
             <measure n="62" xml:id="d1e23938" width="74.324">
               <staff n="1">
                 <layer n="1">
-                  <rest xml:id="d1e23952" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e23952" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e23962" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e23962" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d4451e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e23984" pname="b" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e24006" pname="b" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e23984" pname="b" oct="4" accid.ges="f" />
+                      <note xml:id="d1e24006" pname="b" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e24025" pname="e" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e24025" pname="e" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e24047" pname="g" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e24047" pname="g" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d4459e1" dur="8" dur.ppq="2" stem.dir="down" beam="m1">
-                      <note xml:id="d1e24069" pname="c" oct="5"/>
-                      <note xml:id="d1e24087" pname="c" oct="6"/>
+                      <note xml:id="d1e24069" pname="c" oct="5" />
+                      <note xml:id="d1e24087" pname="c" oct="6" />
                     </chord>
-                    <note xml:id="d1e24104" pname="e" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e24104" pname="e" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
@@ -3998,24 +3659,24 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d4466e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e24130" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e24150" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e24130" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e24150" pname="e" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d4472e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e24169" pname="b" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e24189" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e24208" pname="g" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e24169" pname="b" oct="3" accid.ges="f" />
+                      <note xml:id="d1e24189" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e24208" pname="g" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d4479e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e24227" pname="g" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e24247" pname="g" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e24227" pname="g" oct="2" accid.ges="f" />
+                      <note xml:id="d1e24247" pname="g" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d4485e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e24266" pname="b" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e24286" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e24305" pname="g" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e24266" pname="b" oct="3" accid.ges="f" />
+                      <note xml:id="d1e24286" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e24305" pname="g" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -4026,28 +3687,25 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d4515e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
-                      <note xml:id="d1e24326" pname="b" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e24348" pname="b" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e24326" pname="b" oct="4" accid.ges="f" />
+                      <note xml:id="d1e24348" pname="b" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e24367" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e24389" pname="g" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <chord xml:id="d4523e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e24411" pname="c" oct="5"/>
-                      <note xml:id="d1e24434" pname="c" oct="6"/>
+                    <note xml:id="d1e24367" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e24389" pname="g" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <chord xml:id="d4523e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e24411" pname="c" oct="5" />
+                      <note xml:id="d1e24434" pname="c" oct="6" />
                     </chord>
                   </beam>
                   <beam>
-                    <chord xml:id="d4529e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e24454" pname="c" oct="5"/>
-                      <note xml:id="d1e24477" pname="c" oct="6"/>
+                    <chord xml:id="d4529e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
+                      <note xml:id="d1e24454" pname="c" oct="5" />
+                      <note xml:id="d1e24477" pname="c" oct="6" />
                     </chord>
-                    <note xml:id="d1e24497" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e24497" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d4536e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e24519" pname="b" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e24539" pname="b" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e24519" pname="b" oct="4" accid.ges="f" />
+                      <note xml:id="d1e24539" pname="b" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -4055,54 +3713,52 @@
               <staff n="2">
                 <layer n="1">
                   <chord xml:id="d4542e1" dur="4" dur.ppq="4" stem.dir="down">
-                    <note xml:id="d1e24562" pname="e" oct="2" accid.ges="f"/>
-                    <note xml:id="d1e24580" pname="e" oct="3" accid.ges="f"/>
+                    <note xml:id="d1e24562" pname="e" oct="2" accid.ges="f" />
+                    <note xml:id="d1e24580" pname="e" oct="3" accid.ges="f" />
                   </chord>
                   <beam>
                     <chord xml:id="d4548e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e24599" pname="g" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e24619" pname="g" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e24599" pname="g" oct="2" accid.ges="f" />
+                      <note xml:id="d1e24619" pname="g" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d4554e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e24638" pname="b" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e24658" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e24677" pname="g" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e24638" pname="b" oct="3" accid.ges="f" />
+                      <note xml:id="d1e24658" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e24677" pname="g" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="1.75" startid="#d1e24411" curvedir="above" tstamp2="0m+2"
-                endid="#d1e24454" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e24434" curvedir="above" tstamp2="0m+2"
-                endid="#d1e24477" staff="1"/>
+              <tie tstamp="1.75" startid="#d1e24411" curvedir="below" tstamp2="0m+2" endid="#d1e24454" staff="1" />
+              <tie tstamp="1.75" startid="#d1e24434" curvedir="above" tstamp2="0m+2" endid="#d1e24477" staff="1" />
             </measure>
             <measure n="64" xml:id="d1e24696" width="61.46">
               <staff n="1">
                 <layer n="1">
                   <beam>
                     <chord xml:id="d4588e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e24698" pname="d" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e24718" pname="f" accid="f" oct="5">
-                        <accid accid="f"/>
+                      <note xml:id="d1e24698" pname="d" oct="5" accid.ges="f" />
+                      <note xml:id="d1e24718" pname="f" accid.ges="f" oct="5">
+                        <accid accid="f" />
                       </note>
-                      <note xml:id="d1e24739" pname="d" oct="6" accid.ges="f"/>
+                      <note xml:id="d1e24739" pname="d" oct="6" accid.ges="f" />
                     </chord>
                     <chord xml:id="d4595e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e24758" pname="d" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e24778" pname="f" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e24797" pname="d" oct="6" accid.ges="f"/>
+                      <note xml:id="d1e24758" pname="d" oct="5" accid.ges="f" />
+                      <note xml:id="d1e24778" pname="f" oct="5" accid.ges="f" />
+                      <note xml:id="d1e24797" pname="d" oct="6" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d4602e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e24816" pname="c" oct="5"/>
-                      <note xml:id="d1e24834" pname="f" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e24853" pname="c" oct="6"/>
+                      <note xml:id="d1e24816" pname="c" oct="5" />
+                      <note xml:id="d1e24834" pname="f" oct="5" accid.ges="f" />
+                      <note xml:id="d1e24853" pname="c" oct="6" />
                     </chord>
                     <chord xml:id="d4609e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e24870" pname="b" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e24890" pname="f" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e24910" pname="b" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e24870" pname="b" oct="4" accid.ges="f" />
+                      <note xml:id="d1e24890" pname="f" oct="5" accid.ges="f" />
+                      <note xml:id="d1e24910" pname="b" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -4110,26 +3766,19 @@
               <staff n="2">
                 <layer n="1">
                   <beam>
-                    <note xml:id="d1e24932" pname="g" accid="n" oct="3" dur="16" dur.ppq="1"
-                      beam="i1" stem.dir="down">
-                      <accid accid="n"/>
+                    <note xml:id="d1e24932" pname="g" accid.ges="n" oct="3" dur="16" dur.ppq="1" beam="i1" stem.dir="down">
+                      <accid accid="n" />
                     </note>
-                    <note xml:id="d1e24954" pname="b" oct="3" dur="8" dur.ppq="2" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e24974" pname="d" oct="4" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e24954" pname="b" oct="3" dur="8" dur.ppq="2" beam="m1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e24974" pname="d" oct="4" dur="16" dur.ppq="1" beam="t1" stem.dir="down" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e24996" pname="f" accid="f" oct="4" dur="16" dur.ppq="1"
-                      beam="i1" stem.dir="down">
-                      <accid accid="f"/>
+                    <note xml:id="d1e24996" pname="f" accid.ges="f" oct="4" dur="16" dur.ppq="1" beam="i1" stem.dir="down">
+                      <accid accid="f" />
                     </note>
-                    <note xml:id="d1e25020" pname="d" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e25042" pname="b" oct="3" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e25064" pname="g" oct="3" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down" accid.ges="n"/>
+                    <note xml:id="d1e25020" pname="d" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e25042" pname="b" oct="3" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e25064" pname="g" oct="3" dur="16" dur.ppq="1" beam="t1" stem.dir="down" accid.ges="n" />
                   </beam>
                 </layer>
               </staff>
@@ -4139,32 +3788,29 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d4646e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
-                      <note xml:id="d1e25086" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e25108" pname="f" accid="n" oct="5">
-                        <accid accid="n"/>
+                      <note xml:id="d1e25086" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e25108" pname="f" accid.ges="n" oct="5">
+                        <accid accid="n" />
                       </note>
                     </chord>
-                    <note xml:id="d1e25127" pname="d" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e25149" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <chord xml:id="d4654e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e25171" pname="b" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e25196" pname="g" accid="n" oct="5">
-                        <accid accid="n"/>
+                    <note xml:id="d1e25127" pname="d" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e25149" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <chord xml:id="d4654e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e25171" pname="b" oct="4" accid.ges="f" />
+                      <note xml:id="d1e25196" pname="g" accid.ges="n" oct="5">
+                        <accid accid="n" />
                       </note>
                     </chord>
                   </beam>
                   <beam>
-                    <chord xml:id="d4660e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e25218" pname="b" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e25243" pname="g" oct="5" accid.ges="n"/>
+                    <chord xml:id="d4660e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
+                      <note xml:id="d1e25218" pname="b" oct="4" accid.ges="f" />
+                      <note xml:id="d1e25243" pname="g" oct="5" accid.ges="n" />
                     </chord>
-                    <note xml:id="d1e25263" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e25263" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d4667e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e25285" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e25305" pname="f" oct="5" accid.ges="n"/>
+                      <note xml:id="d1e25285" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e25305" pname="f" oct="5" accid.ges="n" />
                     </chord>
                   </beam>
                 </layer>
@@ -4173,76 +3819,63 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d4673e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e25326" pname="a" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e25346" pname="a" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e25326" pname="a" oct="2" accid.ges="f" />
+                      <note xml:id="d1e25346" pname="a" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d4679e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e25365" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e25385" pname="d" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e25404" pname="f" oct="4"/>
+                      <note xml:id="d1e25365" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e25385" pname="d" oct="4" accid.ges="f" />
+                      <note xml:id="d1e25404" pname="f" oct="4" />
                     </chord>
                   </beam>
                   <beam>
-                    <note xml:id="d1e25421" pname="b" oct="2" dur="8" dur.ppq="2" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e25421" pname="b" oct="2" dur="8" dur.ppq="2" beam="i1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d4687e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e25441" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e25461" pname="b" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e25480" pname="d" accid="n" oct="4">
-                        <accid accid="n"/>
+                      <note xml:id="d1e25441" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e25461" pname="b" oct="3" accid.ges="f" />
+                      <note xml:id="d1e25480" pname="d" accid.ges="n" oct="4">
+                        <accid accid="n" />
                       </note>
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="1.75" startid="#d1e25171" curvedir="above" tstamp2="0m+2"
-                endid="#d1e25218" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e25196" curvedir="above" tstamp2="0m+2"
-                endid="#d1e25243" staff="1"/>
+              <tie tstamp="1.75" startid="#d1e25171" curvedir="below" tstamp2="0m+2" endid="#d1e25218" staff="1" />
+              <tie tstamp="1.75" startid="#d1e25196" curvedir="above" tstamp2="0m+2" endid="#d1e25243" staff="1" />
             </measure>
-            <sb/>
-            <scoreDef system.leftmar="4.2" system.rightmar="0" spacing.system="25.992">
-              <staffGrp>
-                <staffGrp symbol="brace">
-                  <staffDef n="2" spacing="13"/>
-                </staffGrp>
-              </staffGrp>
-            </scoreDef>
+            <sb />
             <measure n="66" xml:id="d1e25499" width="83.56">
               <staff n="1">
                 <layer n="1">
                   <beam>
                     <chord xml:id="d4727e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
-                      <note xml:id="d1e25513" pname="g" accid="n" oct="4">
-                        <accid accid="n"/>
+                      <note xml:id="d1e25513" pname="g" accid.ges="n" oct="4">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e25535" pname="f" oct="5"/>
+                      <note xml:id="d1e25535" pname="f" oct="5" />
                     </chord>
-                    <note xml:id="d1e25552" pname="d" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e25574" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <chord xml:id="d4735e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e25596" pname="g" accid="f" oct="4">
-                        <accid accid="f"/>
+                    <note xml:id="d1e25552" pname="d" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e25574" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <chord xml:id="d4735e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e25596" pname="g" accid.ges="f" oct="4">
+                        <accid accid="f" />
                       </note>
-                      <note xml:id="d1e25623" pname="f" oct="5"/>
+                      <note xml:id="d1e25623" pname="f" oct="5" />
                     </chord>
                   </beam>
                   <beam>
-                    <chord xml:id="d4741e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e25643" pname="g" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e25668" pname="f" oct="5"/>
+                    <chord xml:id="d4741e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
+                      <note xml:id="d1e25643" pname="g" oct="4" accid.ges="f" />
+                      <note xml:id="d1e25668" pname="f" oct="5" />
                     </chord>
-                    <note xml:id="d1e25688" pname="c" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e25688" pname="c" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" />
                     <chord xml:id="d4748e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e25708" pname="g" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e25731" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e25708" pname="g" oct="4" accid.ges="f" />
+                      <note xml:id="d1e25731" pname="e" oct="5" accid.ges="f" />
                     </chord>
-                    <chord xml:id="d4754e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e25750" pname="f" oct="4"/>
-                      <note xml:id="d1e25773" pname="d" oct="5" accid.ges="f"/>
+                    <chord xml:id="d4754e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e25750" pname="f" oct="4" />
+                      <note xml:id="d1e25773" pname="d" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -4251,38 +3884,34 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d4760e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e25798" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e25818" pname="b" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e25837" pname="d" accid="f" oct="4">
-                        <accid accid="f"/>
+                      <note xml:id="d1e25798" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e25818" pname="b" oct="3" accid.ges="f" />
+                      <note xml:id="d1e25837" pname="d" accid.ges="f" oct="4">
+                        <accid accid="f" />
                       </note>
                     </chord>
                     <chord xml:id="d4767e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e25858" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e25878" pname="b" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e25897" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e25858" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e25878" pname="b" oct="3" accid.ges="f" />
+                      <note xml:id="d1e25897" pname="d" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d4774e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e25916" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e25937" pname="c" oct="4"/>
+                      <note xml:id="d1e25916" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e25937" pname="c" oct="4" />
                     </chord>
                     <chord xml:id="d4780e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e25954" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e25974" pname="c" oct="4"/>
+                      <note xml:id="d1e25954" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e25974" pname="c" oct="4" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="1.75" startid="#d1e25596" curvedir="above" tstamp2="0m+2"
-                endid="#d1e25643" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e25623" curvedir="above" tstamp2="0m+2"
-                endid="#d1e25668" staff="1"/>
-              <tie tstamp="2.75" startid="#d1e25750" curvedir="above" tstamp2="1m+1"
-                endid="#d1e25995" staff="1"/>
-              <tie tstamp="2.75" startid="#d1e25773" curvedir="above" tstamp2="1m+1"
-                endid="#d1e26018" staff="1"/>
+              <tie tstamp="1.75" startid="#d1e25596" curvedir="above" tstamp2="0m+2" endid="#d1e25643" staff="1" />
+              <tie tstamp="1.75" startid="#d1e25623" curvedir="above" tstamp2="0m+2" endid="#d1e25668" staff="1" />
+              <tie tstamp="2.75" startid="#d1e25750" curvedir="above" tstamp2="1m+1" endid="#d1e25995" staff="1" />
+              <tie tstamp="2.75" startid="#d1e25773" curvedir="above" tstamp2="1m+1" endid="#d1e26018" staff="1" />
             </measure>
           </section>
           <ending n="1">
@@ -4290,30 +3919,27 @@
               <staff n="1">
                 <layer n="1">
                   <beam>
-                    <chord xml:id="d4825e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e25995" pname="f" oct="4"/>
-                      <note xml:id="d1e26018" pname="d" oct="5" accid.ges="f"/>
+                    <chord xml:id="d4825e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
+                      <note xml:id="d1e25995" pname="f" oct="4" />
+                      <note xml:id="d1e26018" pname="d" oct="5" accid.ges="f" />
                     </chord>
                     <chord xml:id="d4831e1" dur="8" dur.ppq="2" stem.dir="down" beam="m1">
-                      <note xml:id="d1e26040" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e26060" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e26040" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e26060" pname="a" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e26079" pname="f" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e26079" pname="f" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                   <beam>
                     <chord xml:id="d4838e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
-                      <note xml:id="d1e26099" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e26121" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e26099" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e26121" pname="a" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e26140" pname="f" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e26140" pname="f" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" />
                     <chord xml:id="d4845e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e26160" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e26182" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e26160" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e26182" pname="a" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e26202" pname="f" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e26202" pname="f" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                 </layer>
               </staff>
@@ -4321,27 +3947,27 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d4852e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e26225" pname="d" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e26245" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e26225" pname="d" oct="3" accid.ges="f" />
+                      <note xml:id="d1e26245" pname="d" oct="4" accid.ges="f" />
                     </chord>
                     <chord xml:id="d4858e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e26264" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e26284" pname="d" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e26303" pname="f" oct="4"/>
+                      <note xml:id="d1e26264" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e26284" pname="d" oct="4" accid.ges="f" />
+                      <note xml:id="d1e26303" pname="f" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d4865e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e26320" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e26340" pname="d" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e26359" pname="f" oct="4"/>
+                      <note xml:id="d1e26320" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e26340" pname="d" oct="4" accid.ges="f" />
+                      <note xml:id="d1e26359" pname="f" oct="4" />
                     </chord>
                     <chord xml:id="d4872e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e26376" pname="d" accid="n" oct="2">
-                        <accid accid="n"/>
+                      <note xml:id="d1e26376" pname="d" accid.ges="n" oct="2">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e26397" pname="d" accid="n" oct="3">
-                        <accid accid="n"/>
+                      <note xml:id="d1e26397" pname="d" accid.ges="n" oct="3">
+                        <accid accid="n" />
                       </note>
                     </chord>
                   </beam>
@@ -4350,48 +3976,45 @@
             </measure>
           </ending>
           <ending n="2">
-            <measure n="68" xml:id="d1e26421" right="rptstart" width="58.572">
+            <measure n="68" xml:id="d1e26421" right="dbl" width="58.572">
               <staff n="1">
                 <layer n="1">
                   <beam>
                     <chord xml:id="d4901e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
-                      <note xml:id="d1e26425" pname="f" oct="4"/>
-                      <note xml:id="d1e26445" pname="d" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e26425" pname="f" oct="4" />
+                      <note xml:id="d1e26445" pname="d" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e26464" pname="d" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e26486" pname="f" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down"/>
-                    <note xml:id="d1e26506" pname="a" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e26464" pname="d" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e26486" pname="f" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" />
+                    <note xml:id="d1e26506" pname="a" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" accid.ges="f" />
                   </beam>
                   <chord xml:id="d4910e1" dur="8" dur.ppq="2" stem.dir="down">
-                    <note xml:id="d1e26528" pname="d" oct="5" accid.ges="f"/>
-                    <note xml:id="d1e26546" pname="d" oct="6" accid.ges="f"/>
+                    <note xml:id="d1e26528" pname="d" oct="5" accid.ges="f" />
+                    <note xml:id="d1e26546" pname="d" oct="6" accid.ges="f" />
                   </chord>
-                  <rest xml:id="d1e26565" dur="8" dur.ppq="2"/>
+                  <rest xml:id="d1e26565" dur="8" dur.ppq="2" />
                 </layer>
               </staff>
               <staff n="2">
                 <layer n="1">
                   <beam>
                     <chord xml:id="d4918e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e26578" pname="d" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e26599" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e26578" pname="d" oct="3" accid.ges="f" />
+                      <note xml:id="d1e26599" pname="d" oct="4" accid.ges="f" />
                     </chord>
                     <chord xml:id="d4924e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e26618" pname="a" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e26638" pname="a" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e26618" pname="a" oct="2" accid.ges="f" />
+                      <note xml:id="d1e26638" pname="a" oct="3" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d4930e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e26657" pname="d" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e26677" pname="d" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e26657" pname="d" oct="2" accid.ges="f" />
+                      <note xml:id="d1e26677" pname="d" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d4936e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e26696" pname="c" oct="3"/>
-                      <note xml:id="d1e26714" pname="c" oct="4"/>
+                      <note xml:id="d1e26696" pname="c" oct="3" />
+                      <note xml:id="d1e26714" pname="c" oct="4" />
                     </chord>
                   </beam>
                 </layer>
@@ -4399,11 +4022,11 @@
             </measure>
           </ending>
           <section>
-            <scoreDef key.sig="4f" key.mode="major">
+            <scoreDef key.sig="4f" key.mode="major" keysig.showchange="true">
               <staffGrp>
                 <staffGrp symbol="brace">
-                  <staffDef n="1" key.sig="4f"/>
-                  <staffDef n="2" key.sig="4f"/>
+                  <staffDef n="1" key.sig="4f" />
+                  <staffDef n="2" key.sig="4f" />
                 </staffGrp>
               </staffGrp>
             </scoreDef>
@@ -4412,22 +4035,22 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d4963e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e26745" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e26765" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e26745" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e26765" pname="a" oct="5" accid.ges="f" />
                     </chord>
                     <chord xml:id="d4969e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e26784" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e26804" pname="f" oct="5"/>
+                      <note xml:id="d1e26784" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e26804" pname="f" oct="5" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d4975e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e26821" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e26841" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e26821" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e26841" pname="a" oct="5" accid.ges="f" />
                     </chord>
                     <chord xml:id="d4981e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e26860" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e26880" pname="f" oct="5"/>
+                      <note xml:id="d1e26860" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e26880" pname="f" oct="5" />
                     </chord>
                   </beam>
                 </layer>
@@ -4436,66 +4059,56 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d4987e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e26908" pname="d" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e26928" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e26908" pname="d" oct="3" accid.ges="f" />
+                      <note xml:id="d1e26928" pname="d" oct="4" accid.ges="f" />
                     </chord>
                     <chord xml:id="d4993e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e26947" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e26967" pname="d" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e26986" pname="f" oct="4"/>
+                      <note xml:id="d1e26947" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e26967" pname="d" oct="4" accid.ges="f" />
+                      <note xml:id="d1e26986" pname="f" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d5000e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e27003" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e27023" pname="d" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e27042" pname="f" oct="4"/>
+                      <note xml:id="d1e27003" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e27023" pname="d" oct="4" accid.ges="f" />
+                      <note xml:id="d1e27042" pname="f" oct="4" />
                     </chord>
                     <chord xml:id="d5007e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e27059" pname="c" oct="3"/>
-                      <note xml:id="d1e27077" pname="c" oct="4"/>
+                      <note xml:id="d1e27059" pname="c" oct="3" />
+                      <note xml:id="d1e27077" pname="c" oct="4" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
               <dynam label="direction" tstamp="1" place="above" staff="2" val="96">f</dynam>
             </measure>
-            <sb/>
-            <scoreDef system.leftmar="4.2" system.rightmar="0" spacing.system="25.992">
-              <staffGrp>
-                <staffGrp symbol="brace">
-                  <staffDef n="2" spacing="13"/>
-                </staffGrp>
-              </staffGrp>
-            </scoreDef>
+            <sb />
             <measure n="70" xml:id="d1e27094" width="83.906">
               <staff n="1">
                 <layer n="1">
                   <beam>
                     <chord xml:id="d5040e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e27108" pname="f" oct="5"/>
-                      <note xml:id="d1e27126" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e27108" pname="f" oct="5" />
+                      <note xml:id="d1e27126" pname="a" oct="5" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5046e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e27145" pname="f" oct="5"/>
-                      <note xml:id="d1e27165" pname="b" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e27145" pname="f" oct="5" />
+                      <note xml:id="d1e27165" pname="b" oct="5" accid.ges="f" />
                     </chord>
-                    <chord xml:id="d5052e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e27184" pname="f" oct="5"/>
-                      <note xml:id="d1e27207" pname="c" oct="6"/>
+                    <chord xml:id="d5052e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e27184" pname="f" oct="5" />
+                      <note xml:id="d1e27207" pname="c" oct="6" />
                     </chord>
                   </beam>
                   <beam>
-                    <chord xml:id="d5058e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e27227" pname="f" oct="5"/>
-                      <note xml:id="d1e27250" pname="c" oct="6"/>
+                    <chord xml:id="d5058e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
+                      <note xml:id="d1e27227" pname="f" oct="5" />
+                      <note xml:id="d1e27250" pname="c" oct="6" />
                     </chord>
-                    <note xml:id="d1e27270" pname="b" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e27292" pname="a" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e27315" pname="f" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e27270" pname="b" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e27292" pname="a" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e27315" pname="f" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                 </layer>
               </staff>
@@ -4503,52 +4116,48 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d5067e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e27338" pname="d" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e27358" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e27338" pname="d" oct="3" accid.ges="f" />
+                      <note xml:id="d1e27358" pname="d" oct="4" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5073e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e27377" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e27397" pname="d" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e27416" pname="f" oct="4"/>
+                      <note xml:id="d1e27377" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e27397" pname="d" oct="4" accid.ges="f" />
+                      <note xml:id="d1e27416" pname="f" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d5080e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e27433" pname="b" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e27453" pname="b" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e27433" pname="b" oct="2" accid.ges="f" />
+                      <note xml:id="d1e27453" pname="b" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5086e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e27472" pname="b" accid="n" oct="2">
-                        <accid accid="n"/>
+                      <note xml:id="d1e27472" pname="b" accid.ges="n" oct="2">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e27492" pname="b" accid="n" oct="3">
-                        <accid accid="n"/>
+                      <note xml:id="d1e27492" pname="b" accid.ges="n" oct="3">
+                        <accid accid="n" />
                       </note>
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="1.75" startid="#d1e27184" curvedir="above" tstamp2="0m+2"
-                endid="#d1e27227" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e27207" curvedir="above" tstamp2="0m+2"
-                endid="#d1e27250" staff="1"/>
+              <tie tstamp="1.75" startid="#d1e27184" curvedir="below" tstamp2="0m+2" endid="#d1e27227" staff="1" />
+              <tie tstamp="1.75" startid="#d1e27207" curvedir="above" tstamp2="0m+2" endid="#d1e27250" staff="1" />
             </measure>
             <measure n="71" xml:id="d1e27511" width="56.874">
               <staff n="1">
                 <layer n="1">
                   <beam>
-                    <note xml:id="d1e27513" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e27535" pname="f" oct="5" dur="8" dur.ppq="2" beam="m1"
-                      stem.dir="down"/>
-                    <chord xml:id="d5125e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e27553" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e27578" pname="c" oct="5"/>
+                    <note xml:id="d1e27513" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e27535" pname="f" oct="5" dur="8" dur.ppq="2" beam="m1" stem.dir="down" />
+                    <chord xml:id="d5125e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e27553" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e27578" pname="c" oct="5" />
                     </chord>
                   </beam>
-                  <chord xml:id="d5131e1" dur="4" dur.ppq="4" stem.dir="down" tie="t">
-                    <note xml:id="d1e27598" pname="a" oct="4" accid.ges="f"/>
-                    <note xml:id="d1e27619" pname="c" oct="5"/>
+                  <chord xml:id="d5131e1" dur="4" dur.ppq="4" stem.dir="down">
+                    <note xml:id="d1e27598" pname="a" oct="4" accid.ges="f" />
+                    <note xml:id="d1e27619" pname="c" oct="5" />
                   </chord>
                 </layer>
               </staff>
@@ -4556,56 +4165,50 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d5137e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e27642" pname="c" oct="3"/>
-                      <note xml:id="d1e27660" pname="c" oct="4"/>
+                      <note xml:id="d1e27642" pname="c" oct="3" />
+                      <note xml:id="d1e27660" pname="c" oct="4" />
                     </chord>
                     <chord xml:id="d5143e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e27677" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e27697" pname="c" oct="4"/>
-                      <note xml:id="d1e27715" pname="e" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e27677" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e27697" pname="c" oct="4" />
+                      <note xml:id="d1e27715" pname="e" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d5150e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e27734" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e27754" pname="c" oct="4"/>
-                      <note xml:id="d1e27771" pname="e" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e27734" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e27754" pname="c" oct="4" />
+                      <note xml:id="d1e27771" pname="e" oct="4" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5157e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e27790" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e27810" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e27790" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e27810" pname="e" oct="3" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="1.75" startid="#d1e27553" curvedir="above" tstamp2="0m+2"
-                endid="#d1e27598" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e27578" curvedir="above" tstamp2="0m+2"
-                endid="#d1e27619" staff="1"/>
+              <tie tstamp="1.75" startid="#d1e27553" curvedir="below" tstamp2="0m+2" endid="#d1e27598" staff="1" />
+              <tie tstamp="1.75" startid="#d1e27578" curvedir="above" tstamp2="0m+2" endid="#d1e27619" staff="1" />
             </measure>
             <measure n="72" xml:id="d1e27829" width="60.434">
               <staff n="1">
                 <layer n="1">
-                  <rest xml:id="d1e27831" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e27831" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e27841" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e27841" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d5193e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e27863" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e27885" pname="f" oct="5"/>
+                      <note xml:id="d1e27863" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e27885" pname="f" oct="5" />
                     </chord>
-                    <note xml:id="d1e27902" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e27902" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e27922" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e27922" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d5201e1" dur="8" dur.ppq="2" stem.dir="down" beam="m1">
-                      <note xml:id="d1e27944" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e27964" pname="f" oct="5"/>
+                      <note xml:id="d1e27944" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e27964" pname="f" oct="5" />
                     </chord>
-                    <note xml:id="d1e27981" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e27981" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                 </layer>
               </staff>
@@ -4613,26 +4216,26 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d5208e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e28004" pname="a" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e28025" pname="a" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e28004" pname="a" oct="2" accid.ges="f" />
+                      <note xml:id="d1e28025" pname="a" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5214e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e28044" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e28064" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e28083" pname="c" oct="4"/>
+                      <note xml:id="d1e28044" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e28064" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e28083" pname="c" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d5221e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e28100" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e28120" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e28100" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e28120" pname="e" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5227e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e28139" pname="a" accid="n" oct="2">
-                        <accid accid="n"/>
+                      <note xml:id="d1e28139" pname="a" accid.ges="n" oct="2">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e28159" pname="a" accid="n" oct="3">
-                        <accid accid="n"/>
+                      <note xml:id="d1e28159" pname="a" accid.ges="n" oct="3">
+                        <accid accid="n" />
                       </note>
                     </chord>
                   </beam>
@@ -4644,19 +4247,18 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d5256e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e28181" pname="g" oct="4"/>
-                      <note xml:id="d1e28199" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e28181" pname="g" oct="4" />
+                      <note xml:id="d1e28199" pname="e" oct="5" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e28218" pname="f" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down"/>
-                    <chord xml:id="d5263e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e28238" pname="g" oct="4"/>
-                      <note xml:id="d1e28261" pname="b" oct="4" accid.ges="f"/>
+                    <note xml:id="d1e28218" pname="f" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" />
+                    <chord xml:id="d5263e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e28238" pname="g" oct="4" />
+                      <note xml:id="d1e28261" pname="b" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
-                  <chord xml:id="d5269e1" dur="4" dur.ppq="4" stem.dir="up" tie="t">
-                    <note xml:id="d1e28283" pname="g" oct="4"/>
-                    <note xml:id="d1e28302" pname="b" oct="4" accid.ges="f"/>
+                  <chord xml:id="d5269e1" dur="4" dur.ppq="4" stem.dir="up">
+                    <note xml:id="d1e28283" pname="g" oct="4" />
+                    <note xml:id="d1e28302" pname="b" oct="4" accid.ges="f" />
                   </chord>
                 </layer>
               </staff>
@@ -4664,68 +4266,56 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d5275e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e28327" pname="b" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e28347" pname="b" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e28327" pname="b" oct="2" accid.ges="f" />
+                      <note xml:id="d1e28347" pname="b" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5281e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e28366" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e28387" pname="g" oct="3"/>
-                      <note xml:id="d1e28404" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e28366" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e28387" pname="g" oct="3" />
+                      <note xml:id="d1e28404" pname="d" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d5288e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e28423" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e28443" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e28423" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e28443" pname="e" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5294e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e28462" pname="a" accid="n" oct="2">
-                        <accid accid="n"/>
+                      <note xml:id="d1e28462" pname="a" accid.ges="n" oct="2">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e28482" pname="a" accid="n" oct="3">
-                        <accid accid="n"/>
+                      <note xml:id="d1e28482" pname="a" accid.ges="n" oct="3">
+                        <accid accid="n" />
                       </note>
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="1.75" startid="#d1e28238" curvedir="above" tstamp2="0m+2"
-                endid="#d1e28283" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e28261" curvedir="above" tstamp2="0m+2"
-                endid="#d1e28302" staff="1"/>
+              <tie tstamp="1.75" startid="#d1e28238" curvedir="below" tstamp2="0m+2" endid="#d1e28283" staff="1" />
+              <tie tstamp="1.75" startid="#d1e28261" curvedir="above" tstamp2="0m+2" endid="#d1e28302" staff="1" />
             </measure>
-            <sb/>
-            <scoreDef system.leftmar="4.2" system.rightmar="0" spacing.system="25.992">
-              <staffGrp>
-                <staffGrp symbol="brace">
-                  <staffDef n="2" spacing="13"/>
-                </staffGrp>
-              </staffGrp>
-            </scoreDef>
+            <sb />
             <measure n="74" xml:id="d1e28501" width="77.238">
               <staff n="1">
                 <layer n="1">
-                  <rest xml:id="d1e28515" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e28515" dur="16" dur.ppq="1" />
                   <beam>
-                    <note xml:id="d1e28525" pname="d" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e28525" pname="d" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d5332e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e28547" pname="g" oct="4"/>
-                      <note xml:id="d1e28567" pname="f" oct="5"/>
+                      <note xml:id="d1e28547" pname="g" oct="4" />
+                      <note xml:id="d1e28567" pname="f" oct="5" />
                     </chord>
-                    <note xml:id="d1e28584" pname="b" oct="4" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e28584" pname="b" oct="4" dur="16" dur.ppq="1" beam="t1" stem.dir="down" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e28606" pname="d" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e28606" pname="d" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d5340e1" dur="8" dur.ppq="2" stem.dir="down" beam="m1">
-                      <note xml:id="d1e28628" pname="g" oct="4"/>
-                      <note xml:id="d1e28646" pname="f" oct="5"/>
+                      <note xml:id="d1e28628" pname="g" oct="4" />
+                      <note xml:id="d1e28646" pname="f" oct="5" />
                     </chord>
-                    <chord xml:id="d5346e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e28663" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e28688" pname="c" oct="5"/>
+                    <chord xml:id="d5346e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e28663" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e28688" pname="c" oct="5" />
                     </chord>
                   </beam>
                 </layer>
@@ -4734,59 +4324,54 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d5352e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e28712" pname="b" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e28732" pname="b" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e28712" pname="b" oct="2" accid.ges="f" />
+                      <note xml:id="d1e28732" pname="b" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5358e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e28751" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e28771" pname="g" oct="3"/>
-                      <note xml:id="d1e28788" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e28751" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e28771" pname="g" oct="3" />
+                      <note xml:id="d1e28788" pname="d" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d5365e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e28807" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e28827" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e28807" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e28827" pname="e" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5371e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e28846" pname="g" oct="2"/>
-                      <note xml:id="d1e28864" pname="g" oct="3"/>
+                      <note xml:id="d1e28846" pname="g" oct="2" />
+                      <note xml:id="d1e28864" pname="g" oct="3" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="2.75" startid="#d1e28663" curvedir="above" tstamp2="1m+1"
-                endid="#d1e28883" staff="1"/>
-              <tie tstamp="2.75" startid="#d1e28688" curvedir="above" tstamp2="1m+1"
-                endid="#d1e28908" staff="1"/>
+              <tie tstamp="2.75" startid="#d1e28663" curvedir="below" tstamp2="1m+1" endid="#d1e28883" staff="1" />
+              <tie tstamp="2.75" startid="#d1e28688" curvedir="above" tstamp2="1m+1" endid="#d1e28908" staff="1" />
             </measure>
             <measure n="75" xml:id="d1e28881" width="62.58">
               <staff n="1">
                 <layer n="1">
                   <beam>
-                    <chord xml:id="d5408e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e28883" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e28908" pname="c" oct="5"/>
+                    <chord xml:id="d5408e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
+                      <note xml:id="d1e28883" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e28908" pname="c" oct="5" />
                     </chord>
-                    <note xml:id="d1e28928" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e28928" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d5415e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e28950" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e28972" pname="f" oct="5"/>
+                      <note xml:id="d1e28950" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e28972" pname="f" oct="5" />
                     </chord>
-                    <note xml:id="d1e28989" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e28989" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e29009" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e29009" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d5423e1" dur="8" dur.ppq="2" stem.dir="down" beam="m1">
-                      <note xml:id="d1e29031" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e29051" pname="f" oct="5"/>
+                      <note xml:id="d1e29031" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e29051" pname="f" oct="5" />
                     </chord>
-                    <chord xml:id="d5429e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e29068" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e29093" pname="c" oct="5"/>
+                    <chord xml:id="d5429e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e29068" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e29093" pname="c" oct="5" />
                     </chord>
                   </beam>
                 </layer>
@@ -4795,59 +4380,53 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d5435e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e29117" pname="a" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e29137" pname="a" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e29117" pname="a" oct="2" accid.ges="f" />
+                      <note xml:id="d1e29137" pname="a" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5441e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e29156" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e29176" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e29195" pname="c" oct="4"/>
+                      <note xml:id="d1e29156" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e29176" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e29195" pname="c" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d5448e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e29212" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e29232" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e29212" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e29232" pname="e" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5454e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e29251" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e29271" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e29290" pname="c" oct="4"/>
+                      <note xml:id="d1e29251" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e29271" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e29290" pname="c" oct="4" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="2.75" startid="#d1e29068" curvedir="above" tstamp2="1m+1"
-                endid="#d1e29309" staff="1"/>
-              <tie tstamp="2.75" startid="#d1e29093" curvedir="above" tstamp2="1m+1"
-                endid="#d1e29334" staff="1"/>
+              <tie tstamp="2.75" startid="#d1e29068" curvedir="below" tstamp2="1m+1" endid="#d1e29309" staff="1" />
+              <tie tstamp="2.75" startid="#d1e29093" curvedir="above" tstamp2="1m+1" endid="#d1e29334" staff="1" />
             </measure>
             <measure n="76" xml:id="d1e29307" width="62.58">
               <staff n="1">
                 <layer n="1">
                   <beam>
-                    <chord xml:id="d5492e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e29309" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e29334" pname="c" oct="5"/>
+                    <chord xml:id="d5492e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
+                      <note xml:id="d1e29309" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e29334" pname="c" oct="5" />
                     </chord>
-                    <note xml:id="d1e29354" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e29354" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d5499e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e29376" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e29398" pname="f" oct="5"/>
+                      <note xml:id="d1e29376" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e29398" pname="f" oct="5" />
                     </chord>
-                    <note xml:id="d1e29415" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e29415" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e29435" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e29435" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d5507e1" dur="8" dur.ppq="2" stem.dir="down" beam="m1">
-                      <note xml:id="d1e29457" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e29477" pname="f" oct="5"/>
+                      <note xml:id="d1e29457" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e29477" pname="f" oct="5" />
                     </chord>
-                    <note xml:id="d1e29494" pname="e" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e29494" pname="e" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
@@ -4855,23 +4434,23 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d5514e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e29520" pname="a" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e29540" pname="a" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e29520" pname="a" oct="2" accid.ges="f" />
+                      <note xml:id="d1e29540" pname="a" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5520e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e29559" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e29579" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e29598" pname="c" oct="4"/>
+                      <note xml:id="d1e29559" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e29579" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e29598" pname="c" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d5527e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e29615" pname="b" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e29635" pname="b" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e29615" pname="b" oct="2" accid.ges="f" />
+                      <note xml:id="d1e29635" pname="b" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5533e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e29654" pname="c" oct="3"/>
-                      <note xml:id="d1e29672" pname="c" oct="4"/>
+                      <note xml:id="d1e29654" pname="c" oct="3" />
+                      <note xml:id="d1e29672" pname="c" oct="4" />
                     </chord>
                   </beam>
                 </layer>
@@ -4882,22 +4461,22 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d5562e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e29691" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e29711" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e29691" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e29711" pname="a" oct="5" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5568e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e29730" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e29750" pname="f" oct="5"/>
+                      <note xml:id="d1e29730" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e29750" pname="f" oct="5" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d5574e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e29767" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e29787" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e29767" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e29787" pname="a" oct="5" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5580e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e29806" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e29826" pname="f" oct="5"/>
+                      <note xml:id="d1e29806" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e29826" pname="f" oct="5" />
                     </chord>
                   </beam>
                 </layer>
@@ -4906,65 +4485,55 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d5586e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e29846" pname="d" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e29866" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e29846" pname="d" oct="3" accid.ges="f" />
+                      <note xml:id="d1e29866" pname="d" oct="4" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5592e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e29886" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e29906" pname="d" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e29925" pname="f" oct="4"/>
+                      <note xml:id="d1e29886" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e29906" pname="d" oct="4" accid.ges="f" />
+                      <note xml:id="d1e29925" pname="f" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d5599e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e29942" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e29962" pname="d" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e29981" pname="f" oct="4"/>
+                      <note xml:id="d1e29942" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e29962" pname="d" oct="4" accid.ges="f" />
+                      <note xml:id="d1e29981" pname="f" oct="4" />
                     </chord>
                     <chord xml:id="d5606e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e29998" pname="c" oct="3"/>
-                      <note xml:id="d1e30016" pname="c" oct="4"/>
+                      <note xml:id="d1e29998" pname="c" oct="3" />
+                      <note xml:id="d1e30016" pname="c" oct="4" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
             </measure>
-            <sb/>
-            <scoreDef system.leftmar="4.2" system.rightmar="0" spacing.system="25.992">
-              <staffGrp>
-                <staffGrp symbol="brace">
-                  <staffDef n="2" spacing="13"/>
-                </staffGrp>
-              </staffGrp>
-            </scoreDef>
+            <sb />
             <measure n="78" xml:id="d1e30033" width="82.862">
               <staff n="1">
                 <layer n="1">
                   <beam>
                     <chord xml:id="d5637e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e30047" pname="f" oct="5"/>
-                      <note xml:id="d1e30065" pname="a" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e30047" pname="f" oct="5" />
+                      <note xml:id="d1e30065" pname="a" oct="5" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5643e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e30084" pname="f" oct="5"/>
-                      <note xml:id="d1e30104" pname="b" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e30084" pname="f" oct="5" />
+                      <note xml:id="d1e30104" pname="b" oct="5" accid.ges="f" />
                     </chord>
-                    <chord xml:id="d5649e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e30123" pname="f" oct="5"/>
-                      <note xml:id="d1e30146" pname="c" oct="6"/>
+                    <chord xml:id="d5649e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e30123" pname="f" oct="5" />
+                      <note xml:id="d1e30146" pname="c" oct="6" />
                     </chord>
                   </beam>
                   <beam>
-                    <chord xml:id="d5655e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e30166" pname="f" oct="5"/>
-                      <note xml:id="d1e30189" pname="c" oct="6"/>
+                    <chord xml:id="d5655e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
+                      <note xml:id="d1e30166" pname="f" oct="5" />
+                      <note xml:id="d1e30189" pname="c" oct="6" />
                     </chord>
-                    <note xml:id="d1e30209" pname="b" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e30231" pname="a" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e30254" pname="f" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e30209" pname="b" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e30231" pname="a" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e30254" pname="f" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                 </layer>
               </staff>
@@ -4972,53 +4541,47 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d5664e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e30277" pname="d" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e30297" pname="d" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e30277" pname="d" oct="3" accid.ges="f" />
+                      <note xml:id="d1e30297" pname="d" oct="4" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5670e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e30316" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e30336" pname="d" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e30355" pname="f" oct="4"/>
+                      <note xml:id="d1e30316" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e30336" pname="d" oct="4" accid.ges="f" />
+                      <note xml:id="d1e30355" pname="f" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d5677e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e30372" pname="b" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e30392" pname="b" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e30372" pname="b" oct="2" accid.ges="f" />
+                      <note xml:id="d1e30392" pname="b" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5683e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e30411" pname="b" accid="n" oct="2">
-                        <accid accid="n"/>
+                      <note xml:id="d1e30411" pname="b" accid.ges="n" oct="2">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e30431" pname="b" accid="n" oct="3">
-                        <accid accid="n"/>
+                      <note xml:id="d1e30431" pname="b" accid.ges="n" oct="3">
+                        <accid accid="n" />
                       </note>
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="1.75" startid="#d1e30123" curvedir="above" tstamp2="0m+2"
-                endid="#d1e30166" staff="1"/>
-              <tie tstamp="1.75" startid="#d1e30146" curvedir="above" tstamp2="0m+2"
-                endid="#d1e30189" staff="1"/>
+              <tie tstamp="1.75" startid="#d1e30123" curvedir="below" tstamp2="0m+2" endid="#d1e30166" staff="1" />
+              <tie tstamp="1.75" startid="#d1e30146" curvedir="above" tstamp2="0m+2" endid="#d1e30189" staff="1" />
             </measure>
             <measure n="79" xml:id="d1e30450" width="56.398">
               <staff n="1">
                 <layer n="1">
                   <beam>
-                    <note xml:id="d1e30452" pname="a" oct="5" dur="8" dur.ppq="2" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e30472" pname="f" oct="5" dur="8" dur.ppq="2" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e30452" pname="a" oct="5" dur="8" dur.ppq="2" beam="i1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e30472" pname="f" oct="5" dur="8" dur.ppq="2" beam="t1" stem.dir="down" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e30490" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
-                    <note xml:id="d1e30512" pname="a" oct="5" dur="8" dur.ppq="2" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
-                    <chord xml:id="d5724e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e30532" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e30557" pname="c" oct="5"/>
+                    <note xml:id="d1e30490" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
+                    <note xml:id="d1e30512" pname="a" oct="5" dur="8" dur.ppq="2" beam="m1" stem.dir="down" accid.ges="f" />
+                    <chord xml:id="d5724e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e30532" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e30557" pname="c" oct="5" />
                     </chord>
                   </beam>
                 </layer>
@@ -5027,60 +4590,55 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d5730e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e30580" pname="c" oct="3"/>
-                      <note xml:id="d1e30598" pname="c" oct="4"/>
+                      <note xml:id="d1e30580" pname="c" oct="3" />
+                      <note xml:id="d1e30598" pname="c" oct="4" />
                     </chord>
                     <chord xml:id="d5736e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e30615" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e30635" pname="c" oct="4"/>
-                      <note xml:id="d1e30653" pname="e" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e30615" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e30635" pname="c" oct="4" />
+                      <note xml:id="d1e30653" pname="e" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d5743e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e30672" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e30692" pname="c" oct="4"/>
-                      <note xml:id="d1e30709" pname="e" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e30672" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e30692" pname="c" oct="4" />
+                      <note xml:id="d1e30709" pname="e" oct="4" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5750e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e30728" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e30748" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e30728" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e30748" pname="e" oct="3" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="2.75" startid="#d1e30532" curvedir="above" tstamp2="1m+1"
-                endid="#d1e30769" staff="1"/>
-              <tie tstamp="2.75" startid="#d1e30557" curvedir="above" tstamp2="1m+1"
-                endid="#d1e30794" staff="1"/>
+              <tie tstamp="2.75" startid="#d1e30532" curvedir="below" tstamp2="1m+1" endid="#d1e30769" staff="1" />
+              <tie tstamp="2.75" startid="#d1e30557" curvedir="above" tstamp2="1m+1" endid="#d1e30794" staff="1" />
             </measure>
             <measure n="80" xml:id="d1e30767" width="59.464">
               <staff n="1">
                 <layer n="1">
                   <beam>
-                    <chord xml:id="d5787e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1" tie="t">
-                      <note xml:id="d1e30769" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e30794" pname="c" oct="5"/>
+                    <chord xml:id="d5787e1" dur="16" dur.ppq="1" stem.dir="down" beam="i1">
+                      <note xml:id="d1e30769" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e30794" pname="c" oct="5" />
                     </chord>
-                    <note xml:id="d1e30814" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e30814" pname="e" oct="5" dur="16" dur.ppq="1" beam="m1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d5794e1" dur="16" dur.ppq="1" stem.dir="down" beam="m1">
-                      <note xml:id="d1e30836" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e30858" pname="f" oct="5"/>
+                      <note xml:id="d1e30836" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e30858" pname="f" oct="5" />
                     </chord>
-                    <note xml:id="d1e30875" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="down"/>
+                    <note xml:id="d1e30875" pname="c" oct="5" dur="16" dur.ppq="1" beam="t1" stem.dir="down" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e30895" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="down" accid.ges="f"/>
+                    <note xml:id="d1e30895" pname="e" oct="5" dur="16" dur.ppq="1" beam="i1" stem.dir="down" accid.ges="f" />
                     <chord xml:id="d5802e1" dur="8" dur.ppq="2" stem.dir="down" beam="m1">
-                      <note xml:id="d1e30917" pname="a" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e30937" pname="f" oct="5"/>
+                      <note xml:id="d1e30917" pname="a" oct="4" accid.ges="f" />
+                      <note xml:id="d1e30937" pname="f" oct="5" />
                     </chord>
-                    <chord xml:id="d5808e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1" tie="i">
-                      <note xml:id="d1e30954" pname="f" oct="4"/>
-                      <note xml:id="d1e30977" pname="a" oct="4" accid.ges="f"/>
+                    <chord xml:id="d5808e1" dur="16" dur.ppq="1" stem.dir="down" beam="t1">
+                      <note xml:id="d1e30954" pname="f" oct="4" />
+                      <note xml:id="d1e30977" pname="a" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -5089,64 +4647,61 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d5814e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e31003" pname="a" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e31023" pname="a" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e31003" pname="a" oct="2" accid.ges="f" />
+                      <note xml:id="d1e31023" pname="a" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5820e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e31042" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e31062" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e31081" pname="c" oct="4"/>
+                      <note xml:id="d1e31042" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e31062" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e31081" pname="c" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d5827e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e31098" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e31118" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e31098" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e31118" pname="e" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5833e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e31137" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e31157" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e31176" pname="c" oct="4"/>
+                      <note xml:id="d1e31137" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e31157" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e31176" pname="c" oct="4" />
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="2.75" startid="#d1e30954" curvedir="above" tstamp2="1m+1"
-                endid="#d1e31195" staff="1"/>
-              <tie tstamp="2.75" startid="#d1e30977" curvedir="above" tstamp2="1m+1"
-                endid="#d1e31218" staff="1"/>
+              <tie tstamp="2.75" startid="#d1e30954" curvedir="below" tstamp2="1m+1" endid="#d1e31195" staff="1" />
+              <tie tstamp="2.75" startid="#d1e30977" curvedir="above" tstamp2="1m+1" endid="#d1e31218" staff="1" />
             </measure>
             <measure n="81" xml:id="d1e31193" width="61.656">
               <staff n="1">
                 <layer n="1">
                   <beam>
-                    <chord xml:id="d5871e1" dur="16" dur.ppq="1" stem.dir="up" beam="i1" tie="t">
-                      <note xml:id="d1e31195" pname="f" oct="4"/>
-                      <note xml:id="d1e31218" pname="a" oct="4" accid.ges="f"/>
+                    <chord xml:id="d5871e1" dur="16" dur.ppq="1" stem.dir="up" beam="i1">
+                      <note xml:id="d1e31195" pname="f" oct="4" />
+                      <note xml:id="d1e31218" pname="a" oct="4" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e31240" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e31240" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="up" accid.ges="f" />
                     <chord xml:id="d5878e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e31262" pname="f" oct="4"/>
-                      <note xml:id="d1e31280" pname="a" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e31262" pname="f" oct="4" />
+                      <note xml:id="d1e31280" pname="a" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d5884e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e31299" pname="f" accid="f" oct="4">
-                        <accid accid="f"/>
+                      <note xml:id="d1e31299" pname="f" accid.ges="f" oct="4">
+                        <accid accid="f" />
                       </note>
-                      <note xml:id="d1e31321" pname="a" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e31321" pname="a" oct="4" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5890e1" dur="16" dur.ppq="1" stem.dir="up" beam="m1">
-                      <note xml:id="d1e31340" pname="f" accid="n" oct="4">
-                        <accid accid="n"/>
+                      <note xml:id="d1e31340" pname="f" accid.ges="n" oct="4">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e31362" pname="b" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e31362" pname="b" oct="4" accid.ges="f" />
                     </chord>
-                    <chord xml:id="d5896e1" dur="16" dur.ppq="1" stem.dir="up" beam="t1" tie="i">
-                      <note xml:id="d1e31381" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e31406" pname="a" oct="4" accid.ges="f"/>
+                    <chord xml:id="d5896e1" dur="16" dur.ppq="1" stem.dir="up" beam="t1">
+                      <note xml:id="d1e31381" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e31406" pname="a" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -5155,72 +4710,60 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d5902e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e31432" pname="d" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e31452" pname="d" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e31432" pname="d" oct="2" accid.ges="f" />
+                      <note xml:id="d1e31452" pname="d" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5908e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e31471" pname="d" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e31491" pname="d" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e31471" pname="d" oct="2" accid.ges="f" />
+                      <note xml:id="d1e31491" pname="d" oct="3" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d5914e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e31510" pname="b" oct="1" accid.ges="f"/>
-                      <note xml:id="d1e31530" pname="b" oct="2" accid.ges="f"/>
+                      <note xml:id="d1e31510" pname="b" oct="1" accid.ges="f" />
+                      <note xml:id="d1e31530" pname="b" oct="2" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5920e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e31549" pname="d" accid="n" oct="2">
-                        <accid accid="n"/>
+                      <note xml:id="d1e31549" pname="d" accid.ges="n" oct="2">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e31569" pname="d" accid="n" oct="3">
-                        <accid accid="n"/>
+                      <note xml:id="d1e31569" pname="d" accid.ges="n" oct="3">
+                        <accid accid="n" />
                       </note>
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="2.75" startid="#d1e31381" curvedir="below" tstamp2="1m+1"
-                endid="#d1e31602" staff="1"/>
-              <tie tstamp="2.75" startid="#d1e31406" curvedir="below" tstamp2="1m+1"
-                endid="#d1e31627" staff="1"/>
+              <tie tstamp="2.75" startid="#d1e31381" curvedir="below" tstamp2="1m+1" endid="#d1e31602" staff="1" />
+              <tie tstamp="2.75" startid="#d1e31406" curvedir="above" tstamp2="1m+1" endid="#d1e31627" staff="1" />
             </measure>
-            <sb/>
-            <scoreDef system.leftmar="4.2" system.rightmar="0" spacing.system="25.992">
-              <staffGrp>
-                <staffGrp symbol="brace">
-                  <staffDef n="2" spacing="13"/>
-                </staffGrp>
-              </staffGrp>
-            </scoreDef>
+            <sb />
             <measure n="82" xml:id="d1e31588" width="79.174">
               <staff n="1">
                 <layer n="1">
                   <beam>
-                    <chord xml:id="d5959e1" dur="16" dur.ppq="1" stem.dir="up" beam="i1" tie="t">
-                      <note xml:id="d1e31602" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e31627" pname="a" oct="4" accid.ges="f"/>
+                    <chord xml:id="d5959e1" dur="16" dur.ppq="1" stem.dir="up" beam="i1">
+                      <note xml:id="d1e31602" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e31627" pname="a" oct="4" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e31649" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e31649" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="up" accid.ges="f" />
                     <chord xml:id="d5966e1" dur="16" dur.ppq="1" stem.dir="up" beam="m1">
-                      <note xml:id="d1e31671" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e31693" pname="c" oct="5"/>
+                      <note xml:id="d1e31671" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e31693" pname="c" oct="5" />
                     </chord>
-                    <note xml:id="d1e31710" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e31710" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1" stem.dir="up" accid.ges="f" />
                   </beam>
                   <beam>
-                    <note xml:id="d1e31732" pname="b" oct="4" dur="16" dur.ppq="1" beam="i1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e31732" pname="b" oct="4" dur="16" dur.ppq="1" beam="i1" stem.dir="up" accid.ges="f" />
                     <chord xml:id="d5974e1" dur="8" dur.ppq="2" stem.dir="up" beam="m1">
-                      <note xml:id="d1e31754" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e31774" pname="c" oct="5"/>
+                      <note xml:id="d1e31754" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e31774" pname="c" oct="5" />
                     </chord>
-                    <chord xml:id="d5980e1" dur="16" dur.ppq="1" stem.dir="up" beam="t1" tie="i">
-                      <note xml:id="d1e31791" pname="d" accid="n" oct="4">
-                        <accid accid="n"/>
+                    <chord xml:id="d5980e1" dur="16" dur.ppq="1" stem.dir="up" beam="t1">
+                      <note xml:id="d1e31791" pname="d" accid.ges="n" oct="4">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e31817" pname="a" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e31817" pname="a" oct="4" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -5229,65 +4772,60 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d5986e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e31842" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e31862" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e31842" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e31862" pname="e" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d5992e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e31881" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e31901" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e31920" pname="c" oct="4"/>
+                      <note xml:id="d1e31881" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e31901" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e31920" pname="c" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d5999e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e31937" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e31957" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e31937" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e31957" pname="e" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d6005e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e31976" pname="e" accid="n" oct="2">
-                        <accid accid="n"/>
+                      <note xml:id="d1e31976" pname="e" accid.ges="n" oct="2">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e31996" pname="e" accid="n" oct="3">
-                        <accid accid="n"/>
+                      <note xml:id="d1e31996" pname="e" accid.ges="n" oct="3">
+                        <accid accid="n" />
                       </note>
                     </chord>
                   </beam>
                 </layer>
               </staff>
-              <tie tstamp="2.75" startid="#d1e31791" curvedir="below" tstamp2="1m+1"
-                endid="#d1e32017" staff="1"/>
-              <tie tstamp="2.75" startid="#d1e31817" curvedir="below" tstamp2="1m+1"
-                endid="#d1e32040" staff="1"/>
+              <tie tstamp="2.75" startid="#d1e31791" curvedir="below" tstamp2="1m+1" endid="#d1e32017" staff="1" />
+              <tie tstamp="2.75" startid="#d1e31817" curvedir="above" tstamp2="1m+1" endid="#d1e32040" staff="1" />
             </measure>
             <measure n="83" xml:id="d1e32015" width="66.552">
               <staff n="1">
                 <layer n="1">
                   <beam>
-                    <chord xml:id="d6042e1" dur="16" dur.ppq="1" stem.dir="up" beam="i1" tie="t">
-                      <note xml:id="d1e32017" pname="d" oct="4"/>
-                      <note xml:id="d1e32040" pname="a" oct="4" accid.ges="f"/>
+                    <chord xml:id="d6042e1" dur="16" dur.ppq="1" stem.dir="up" beam="i1">
+                      <note xml:id="d1e32017" pname="d" oct="4" />
+                      <note xml:id="d1e32040" pname="a" oct="4" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e32062" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e32062" pname="b" oct="4" dur="16" dur.ppq="1" beam="m1" stem.dir="up" accid.ges="f" />
                     <chord xml:id="d6049e1" dur="16" dur.ppq="1" stem.dir="up" beam="m1">
-                      <note xml:id="d1e32084" pname="d" accid="n" oct="4">
-                        <accid accid="n"/>
+                      <note xml:id="d1e32084" pname="d" accid.ges="n" oct="4">
+                        <accid accid="n" />
                       </note>
-                      <note xml:id="d1e32106" pname="c" oct="5"/>
+                      <note xml:id="d1e32106" pname="c" oct="5" />
                     </chord>
-                    <note xml:id="d1e32123" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e32123" pname="a" oct="4" dur="16" dur.ppq="1" beam="t1" stem.dir="up" accid.ges="f" />
                   </beam>
-                  <rest xml:id="d1e32145" dur="16" dur.ppq="1"/>
+                  <rest xml:id="d1e32145" dur="16" dur.ppq="1" />
                   <beam>
                     <chord xml:id="d6058e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e32155" pname="d" accid="f" oct="4">
-                        <accid accid="f"/>
+                      <note xml:id="d1e32155" pname="d" accid.ges="f" oct="4">
+                        <accid accid="f" />
                       </note>
-                      <note xml:id="d1e32177" pname="b" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e32177" pname="b" oct="4" accid.ges="f" />
                     </chord>
-                    <note xml:id="d1e32196" pname="e" oct="4" dur="16" dur.ppq="1" beam="t1"
-                      stem.dir="up" accid.ges="f"/>
+                    <note xml:id="d1e32196" pname="e" oct="4" dur="16" dur.ppq="1" beam="t1" stem.dir="up" accid.ges="f" />
                   </beam>
                 </layer>
               </staff>
@@ -5295,22 +4833,22 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d6065e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e32222" pname="f" oct="2"/>
-                      <note xml:id="d1e32240" pname="f" oct="3"/>
+                      <note xml:id="d1e32222" pname="f" oct="2" />
+                      <note xml:id="d1e32240" pname="f" oct="3" />
                     </chord>
                     <chord xml:id="d6071e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e32257" pname="f" oct="2"/>
-                      <note xml:id="d1e32275" pname="f" oct="3"/>
+                      <note xml:id="d1e32257" pname="f" oct="2" />
+                      <note xml:id="d1e32275" pname="f" oct="3" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d6077e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e32292" pname="g" oct="2"/>
-                      <note xml:id="d1e32310" pname="g" oct="3"/>
+                      <note xml:id="d1e32292" pname="g" oct="2" />
+                      <note xml:id="d1e32310" pname="g" oct="3" />
                     </chord>
                     <chord xml:id="d6083e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e32327" pname="g" oct="2"/>
-                      <note xml:id="d1e32345" pname="g" oct="3"/>
+                      <note xml:id="d1e32327" pname="g" oct="2" />
+                      <note xml:id="d1e32345" pname="g" oct="3" />
                     </chord>
                   </beam>
                 </layer>
@@ -5323,22 +4861,22 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d6112e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e32367" pname="c" oct="4"/>
-                      <note xml:id="d1e32385" pname="a" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e32367" pname="c" oct="4" />
+                      <note xml:id="d1e32385" pname="a" oct="4" accid.ges="f" />
                     </chord>
                     <chord xml:id="d6118e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e32404" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e32424" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e32404" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e32424" pname="e" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d6124e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e32443" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e32463" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e32443" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e32463" pname="e" oct="5" accid.ges="f" />
                     </chord>
                     <chord xml:id="d6130e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e32482" pname="e" oct="4" accid.ges="f"/>
-                      <note xml:id="d1e32502" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e32482" pname="e" oct="4" accid.ges="f" />
+                      <note xml:id="d1e32502" pname="e" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                 </layer>
@@ -5347,23 +4885,23 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d6136e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e32524" pname="a" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e32545" pname="a" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e32524" pname="a" oct="2" accid.ges="f" />
+                      <note xml:id="d1e32545" pname="a" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d6142e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e32564" pname="e" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e32584" pname="a" oct="3" accid.ges="f"/>
-                      <note xml:id="d1e32603" pname="c" oct="4"/>
+                      <note xml:id="d1e32564" pname="e" oct="3" accid.ges="f" />
+                      <note xml:id="d1e32584" pname="a" oct="3" accid.ges="f" />
+                      <note xml:id="d1e32603" pname="c" oct="4" />
                     </chord>
                   </beam>
                   <beam>
                     <chord xml:id="d6149e1" dur="8" dur.ppq="2" stem.dir="down" beam="i1">
-                      <note xml:id="d1e32620" pname="b" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e32640" pname="b" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e32620" pname="b" oct="2" accid.ges="f" />
+                      <note xml:id="d1e32640" pname="b" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d6155e1" dur="8" dur.ppq="2" stem.dir="down" beam="t1">
-                      <note xml:id="d1e32659" pname="c" oct="3"/>
-                      <note xml:id="d1e32677" pname="c" oct="4"/>
+                      <note xml:id="d1e32659" pname="c" oct="3" />
+                      <note xml:id="d1e32677" pname="c" oct="4" />
                     </chord>
                   </beam>
                 </layer>
@@ -5376,41 +4914,41 @@
                 <layer n="1">
                   <beam>
                     <chord xml:id="d6184e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e32703" pname="c" oct="4"/>
-                      <note xml:id="d1e32721" pname="a" oct="4" accid.ges="f"/>
+                      <note xml:id="d1e32703" pname="c" oct="4" />
+                      <note xml:id="d1e32721" pname="a" oct="4" accid.ges="f" />
                     </chord>
                     <chord xml:id="d6190e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e32740" pname="g" oct="4"/>
-                      <note xml:id="d1e32758" pname="d" oct="5" accid.ges="f"/>
-                      <note xml:id="d1e32777" pname="e" oct="5" accid.ges="f"/>
+                      <note xml:id="d1e32740" pname="g" oct="4" />
+                      <note xml:id="d1e32758" pname="d" oct="5" accid.ges="f" />
+                      <note xml:id="d1e32777" pname="e" oct="5" accid.ges="f" />
                     </chord>
                   </beam>
                   <chord xml:id="d6197e1" dur="8" dur.ppq="2" stem.dir="down">
-                    <note xml:id="d1e32796" pname="a" oct="4" accid.ges="f"/>
-                    <note xml:id="d1e32814" pname="c" oct="5"/>
-                    <note xml:id="d1e32831" pname="e" oct="5" accid.ges="f"/>
-                    <note xml:id="d1e32850" pname="a" oct="5" accid.ges="f"/>
+                    <note xml:id="d1e32796" pname="a" oct="4" accid.ges="f" />
+                    <note xml:id="d1e32814" pname="c" oct="5" />
+                    <note xml:id="d1e32831" pname="e" oct="5" accid.ges="f" />
+                    <note xml:id="d1e32850" pname="a" oct="5" accid.ges="f" />
                   </chord>
-                  <rest xml:id="d1e32869" dur="8" dur.ppq="2"/>
+                  <rest xml:id="d1e32869" dur="8" dur.ppq="2" />
                 </layer>
               </staff>
               <staff n="2">
                 <layer n="1">
                   <beam>
                     <chord xml:id="d6207e1" dur="8" dur.ppq="2" stem.dir="up" beam="i1">
-                      <note xml:id="d1e32883" pname="a" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e32903" pname="a" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e32883" pname="a" oct="2" accid.ges="f" />
+                      <note xml:id="d1e32903" pname="a" oct="3" accid.ges="f" />
                     </chord>
                     <chord xml:id="d6213e1" dur="8" dur.ppq="2" stem.dir="up" beam="t1">
-                      <note xml:id="d1e32922" pname="e" oct="2" accid.ges="f"/>
-                      <note xml:id="d1e32942" pname="e" oct="3" accid.ges="f"/>
+                      <note xml:id="d1e32922" pname="e" oct="2" accid.ges="f" />
+                      <note xml:id="d1e32942" pname="e" oct="3" accid.ges="f" />
                     </chord>
                   </beam>
                   <chord xml:id="d6219e1" dur="8" dur.ppq="2" stem.dir="up">
-                    <note xml:id="d1e32961" pname="a" oct="1" accid.ges="f"/>
-                    <note xml:id="d1e32979" pname="a" oct="2" accid.ges="f"/>
+                    <note xml:id="d1e32961" pname="a" oct="1" accid.ges="f" />
+                    <note xml:id="d1e32979" pname="a" oct="2" accid.ges="f" />
                   </chord>
-                  <rest xml:id="d1e32998" dur="8" dur.ppq="2"/>
+                  <rest xml:id="d1e32998" dur="8" dur.ppq="2" />
                 </layer>
               </staff>
             </measure>


### PR DESCRIPTION
This PR brings following:
* Changed doubled accid attribute on note to accid.ges
* Removed tie attributes
* Fixed clef changes
* Added missing rests
* Removed unnessesary scoreDefs
* Formatting

fixes #61
