### PR TITLE
Some sample encodings for perfMedium

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+MEI_4.0/Header/.DS_Store

--- a/MEI_4.0/Header/PerfMedium/chamber/duo/Haessler_JohannWilhelm_SechsLeichteSonaten_sonata_IV-V.xml
+++ b/MEI_4.0/Header/PerfMedium/chamber/duo/Haessler_JohannWilhelm_SechsLeichteSonaten_sonata_IV-V.xml
@@ -6,9 +6,10 @@
    
    <perfResList label="Sonata IV–V">
       <perfRes auth="ka">piano</perfRes>
-      <perfResList>
-         <perfRes auth="sa" type="alt">violin</perfRes>
-         <perfRes auth="wa" type="alt">flute</perfRes>
+      <perfResList type="alternatives">
+         <perfRes auth="sa">violin</perfRes>
+         <!-- or -->
+         <perfRes auth="wa">flute</perfRes>
       </perfResList>
    </perfResList>
    

--- a/MEI_4.0/Header/PerfMedium/chamber/duo/Haessler_JohannWilhelm_SechsLeichteSonaten_sonata_IV-V.xml
+++ b/MEI_4.0/Header/PerfMedium/chamber/duo/Haessler_JohannWilhelm_SechsLeichteSonaten_sonata_IV-V.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+   <head>Sechs leichte Sonaten fürs Clavier oder Piano=Forte, | wovon | Zwei mit Begleitung einer Flöte oder Violine | und | Eine für drei Hände auf Einem Claviere, | von | Johann Wilhelm Häßler, | Musikdirektor des öffentlichen Konzerts und Organist an der Barfüßerkirche in Erfurth.</head>
+   
+   <perfResList label="Sonata IV–V">
+      <perfRes auth="ka">piano</perfRes>
+      <perfResList>
+         <perfRes auth="sa" type="alt">violin</perfRes>
+         <perfRes auth="wa" type="alt">flute</perfRes>
+      </perfResList>
+   </perfResList>
+   
+   <annot>@auth.uri for the following &lt;perfRes/&gt; is https://www.loc.gov/standards/valuelist/marcmusperf.html</annot>
+   <annot>The score is available on IMSLP: https://imslp.org/wiki/6_Leichte_Sonaten%2C_Theil_1_(H%C3%A4ssler%2C_Johann_Wilhelm)</annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/chamber/duo/Haessler_JohannWilhelm_SechsLeichteSonaten_sonata_IV-V.xml
+++ b/MEI_4.0/Header/PerfMedium/chamber/duo/Haessler_JohannWilhelm_SechsLeichteSonaten_sonata_IV-V.xml
@@ -5,11 +5,11 @@
    <head>Sechs leichte Sonaten fürs Clavier oder Piano=Forte, | wovon | Zwei mit Begleitung einer Flöte oder Violine | und | Eine für drei Hände auf Einem Claviere, | von | Johann Wilhelm Häßler, | Musikdirektor des öffentlichen Konzerts und Organist an der Barfüßerkirche in Erfurth.</head>
    
    <perfResList label="Sonata IV–V">
-      <perfRes auth="ka">piano</perfRes>
+      <perfRes codedval="ka">piano</perfRes>
       <perfResList type="alternatives">
-         <perfRes auth="sa">violin</perfRes>
+         <perfRes codedval="sa">violin</perfRes>
          <!-- or -->
-         <perfRes auth="wa">flute</perfRes>
+         <perfRes codedval="wa">flute</perfRes>
       </perfResList>
    </perfResList>
    

--- a/MEI_4.0/Header/PerfMedium/chamber/ensemble_orchestra/Beethoven_LudwigVan_GrandeFugue_Op133.xml
+++ b/MEI_4.0/Header/PerfMedium/chamber/ensemble_orchestra/Beethoven_LudwigVan_GrandeFugue_Op133.xml
@@ -6,10 +6,10 @@
    
    <perfResList>
       <!-- string ensemble/orchestra @count > 1 -->
-      <perfRes auth="sa" label="violin.i">Violin I</perfRes>
-      <perfRes auth="sa" label="violin.ii">Violin II</perfRes>
-      <perfRes auth="sb" label="viola">Viola</perfRes>
-      <perfRes auth="sc" label="violoncello">Violoncello</perfRes>
+      <perfRes label="violin.i" codedval="sa">Violin I</perfRes>
+      <perfRes label="violin.ii" codedval="sa">Violin II</perfRes>
+      <perfRes label="viola" codedval="sb">Viola</perfRes>
+      <perfRes label="violoncello" codedval="sc">Violoncello</perfRes>
    </perfResList>
    
    <annot>@auth.uri for the following &lt;perfRes/&gt; is https://www.loc.gov/standards/valuelist/marcmusperf.html</annot>

--- a/MEI_4.0/Header/PerfMedium/chamber/ensemble_orchestra/Beethoven_LudwigVan_GrandeFugue_Op133.xml
+++ b/MEI_4.0/Header/PerfMedium/chamber/ensemble_orchestra/Beethoven_LudwigVan_GrandeFugue_Op133.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+   <head>Partition | de la | Grande Fugue | pur | Violons, Alte &amp; Violoncelle | Louis van Beethoven | Oeuvre 133</head>
+   
+   <perfResList>
+      <!-- string ensemble/orchestra @count > 1 -->
+      <perfRes auth="sa" label="violin.i">Violin I</perfRes>
+      <perfRes auth="sa" label="violin.ii">Violin II</perfRes>
+      <perfRes auth="sb" label="viola">Viola</perfRes>
+      <perfRes auth="sc" label="violoncello">Violoncello</perfRes>
+   </perfResList>
+   
+   <annot>@auth.uri for the following &lt;perfRes/&gt; is https://www.loc.gov/standards/valuelist/marcmusperf.html</annot>
+   <annot>The score is available on IMSLP: https://imslp.org/wiki/Gro%C3%9Fe_Fuge_for_Piano_Four_Hands,_Op.134_(Beethoven,_Ludwig_van)</annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/instrumentsAndPerfomers/moreInstrumentsThanPerformers.xml
+++ b/MEI_4.0/Header/PerfMedium/instrumentsAndPerfomers/moreInstrumentsThanPerformers.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+    <head>Example if one player (here flute 3 and percussions) performs on more than one instrument</head>
+    <castList type="performers">
+        <castItem xml:id="perf.flute-01">Performer flute (I)</castItem>
+        <castItem xml:id="perf.flute-02">Performer flute (II)</castItem>
+        <castItem xml:id="perf.flute-03">Performer flute (III)</castItem>
+        <castItem xml:id="perf.perc-01">Performer percussion</castItem>
+    </castList>
+    <perfResList>
+        <perfResList auth="winds">
+            <perfRes count="1" corresp="#perf.flute-03">piccolo</perfRes>
+            <perfRes count="1" corresp="#perf.flute-01">flute I</perfRes>
+            <perfRes count="1" corresp="#perf.flute-02">flute II</perfRes>
+            <perfRes count="1" corresp="#perf.flute-03">flute III</perfRes>
+        </perfResList>
+        <perfResList auth="percussion">
+            <!-- Here The group is somewhere else -->
+            <perfRes count="1" corresp="#perf.perc-01">bass drum</perfRes>
+            <perfRes count="1" corresp="#perf.perc-01">snare drum</perfRes>
+            <perfRes count="1" corresp="#perf.perc-01">hi-hat</perfRes>
+        </perfResList>
+    </perfResList>
+    <annot>
+        <list>
+            <head>There are two different things in here:</head>
+            <li>1. The performance resources that are needed to perform a work.</li>
+            <li>2. The (number/kind of) people that are needed to perform a work.</li>
+        </list>
+    </annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/instrumentsAndPerfomers/moreInstrumentsThanPerformers.xml
+++ b/MEI_4.0/Header/PerfMedium/instrumentsAndPerfomers/moreInstrumentsThanPerformers.xml
@@ -10,13 +10,13 @@
         <castItem xml:id="perf.perc-01">Performer percussion</castItem>
     </castList>
     <perfResList>
-        <perfResList auth="winds">
+        <perfResList codedval="winds">
             <perfRes count="1" corresp="#perf.flute-03">piccolo</perfRes>
             <perfRes count="1" corresp="#perf.flute-01">flute I</perfRes>
             <perfRes count="1" corresp="#perf.flute-02">flute II</perfRes>
             <perfRes count="1" corresp="#perf.flute-03">flute III</perfRes>
         </perfResList>
-        <perfResList auth="percussion">
+        <perfResList codedval="percussion">
             <!-- Here The group is somewhere else -->
             <perfRes count="1" corresp="#perf.perc-01">bass drum</perfRes>
             <perfRes count="1" corresp="#perf.perc-01">snare drum</perfRes>

--- a/MEI_4.0/Header/PerfMedium/organ/1_performer/Bach_JohannSebastian_PedalExercitium_BWV598.xml
+++ b/MEI_4.0/Header/PerfMedium/organ/1_performer/Bach_JohannSebastian_PedalExercitium_BWV598.xml
@@ -5,7 +5,7 @@
    <head>Bach, Johann Sebastian: Pedal-Exercitium, BWV 598</head>
    
    <perfResList>
-      <perfRes auth="kb" label="organ">
+      <perfRes label="organ" codedval="kb">
          <perfRes label="pedal" solo="true">pedal solo (2 feet)</perfRes>
       </perfRes>
    </perfResList>

--- a/MEI_4.0/Header/PerfMedium/organ/1_performer/Bach_JohannSebastian_PedalExercitium_BWV598.xml
+++ b/MEI_4.0/Header/PerfMedium/organ/1_performer/Bach_JohannSebastian_PedalExercitium_BWV598.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+   <head>Bach, Johann Sebastian: Pedal-Exercitium, BWV 598</head>
+   
+   <perfResList>
+      <perfRes auth="kb" label="organ">
+         <perfRes label="pedal" solo="true">pedal solo (2 feet)</perfRes>
+      </perfRes>
+   </perfResList>
+   
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/organ/2_performers/Strauss_Johann-Jun_ValsForOrganPedal.xml
+++ b/MEI_4.0/Header/PerfMedium/organ/2_performers/Strauss_Johann-Jun_ValsForOrganPedal.xml
@@ -4,7 +4,7 @@
 <perfMedium xmlns="http://www.music-encoding.org/ns/mei">
    <head>Strauß, Johann (jun.): Vals for organ pedal (for 2 performers/4 feet)</head>
    <perfResList>
-      <perfRes auth="kb" label="organ">
+      <perfRes label="organ" codedval="kb">
          <perfRes label="pedal" solo="true">
             <perfRes label="perf.i">2 feet</perfRes>
             <perfRes label="perf.ii">2 feet</perfRes>

--- a/MEI_4.0/Header/PerfMedium/organ/2_performers/Strauss_Johann-Jun_ValsForOrganPedal.xml
+++ b/MEI_4.0/Header/PerfMedium/organ/2_performers/Strauss_Johann-Jun_ValsForOrganPedal.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+   <head>Strauß, Johann (jun.): Vals for organ pedal (for 2 performers/4 feet)</head>
+   <perfResList>
+      <perfRes auth="kb" label="organ">
+         <perfRes label="pedal" solo="true">
+            <perfRes label="perf.i">2 feet</perfRes>
+            <perfRes label="perf.ii">2 feet</perfRes>
+         </perfRes>
+      </perfRes>
+   </perfResList>
+   <annot>
+      <head>Information given here:</head>
+      <list>
+         <li>An organ that has pedals is needed</li>
+         <li>Two performers are needed</li>
+         <li>Both performers have to play just with their feet</li>
+      </list></annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/organ/2_performers/Strauss_Johann-Jun_WaltzForOrganPedal.xml
+++ b/MEI_4.0/Header/PerfMedium/organ/2_performers/Strauss_Johann-Jun_WaltzForOrganPedal.xml
@@ -2,7 +2,7 @@
 <?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <perfMedium xmlns="http://www.music-encoding.org/ns/mei">
-   <head>Strauß, Johann (jun.): Vals for organ pedal (for 2 performers/4 feet)</head>
+   <head>Strauß, Johann (jun.): Waltz for organ pedal (for 2 performers/4 feet)</head>
    <perfResList>
       <perfRes label="organ" codedval="kb">
          <perfRes label="pedal" solo="true">

--- a/MEI_4.0/Header/PerfMedium/organ/Liszt_Franz_OssaArida_choirAndOrgan.xml
+++ b/MEI_4.0/Header/PerfMedium/organ/Liszt_Franz_OssaArida_choirAndOrgan.xml
@@ -6,10 +6,10 @@
    </head>
    <perfResList>
       <perfResList label="choirMens" type="unanimous">
-         <perfRes auth="vd">tenor</perfRes>
-         <perfRes auth="vf">bass</perfRes>
+         <perfRes codedval="vd">tenor</perfRes>
+         <perfRes codedval="vf">bass</perfRes>
       </perfResList>
-      <perfRes auth="kb" label="organ">
+      <perfRes label="organ" codedval="kb">
          <perfRes label="perf.i">
             <perfRes label="hand">right Hand</perfRes>
             <perfRes label="hand">left Hand</perfRes>

--- a/MEI_4.0/Header/PerfMedium/organ/Liszt_Franz_OssaArida_choirAndOrgan.xml
+++ b/MEI_4.0/Header/PerfMedium/organ/Liszt_Franz_OssaArida_choirAndOrgan.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+   <head>Liszt, Franz: Ossa Arida (choir and organ [4 hands, 2 feet])
+   </head>
+   <perfResList>
+      <perfResList label="choirMens" type="unanimous">
+         <perfRes auth="vd">tenor</perfRes>
+         <perfRes auth="vf">bass</perfRes>
+      </perfResList>
+      <perfRes auth="kb" label="organ">
+         <perfRes label="perf.i">
+            <perfRes label="hand">right Hand</perfRes>
+            <perfRes label="hand">left Hand</perfRes>
+         </perfRes>
+         <perfRes label="perf.ii">
+            <perfRes label="hand">right Hand</perfRes>
+            <perfRes label="hand">left Hand</perfRes>
+            <perfRes label="feet">right and left Foot</perfRes>
+         </perfRes>
+      </perfRes>
+   </perfResList>
+   <annot>
+      <head>Information given here:</head>
+      <list>
+         <li>A male choir is needed</li>
+         <li>the choir sings unisono</li>
+         <li>An organ that has pedals is needed</li>
+         <li>Two performers are needed</li>
+         <li>Just the second organ part played with hands and feet</li>
+      </list></annot>
+   <annot>With score on Youtube: https://youtu.be/gdlv_roaVyU</annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/piano/1_hand/Bach_CarlPhilippEmanuel_ClavierstueckFuerDieRechteOderLinkeHandAllein.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/1_hand/Bach_CarlPhilippEmanuel_ClavierstueckFuerDieRechteOderLinkeHandAllein.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+    <head>Bach, Carl Philipp Emanuel: Clavierstück für die rechte oder linke Hand allein.</head>
+    
+    <perfResList>
+        <perfRes auth="ka" label="piano">
+            <!-- alternatives! -->
+            <perfRes label="hand" solo="true" type="alt">right</perfRes>
+            <perfRes label="hand" solo="true" type="alt">left</perfRes>
+        </perfRes>
+    </perfResList>
+    
+    <annot>@auth.uri for the following &lt;perfRes/&gt; is https://www.loc.gov/standards/valuelist/marcmusperf.html</annot>
+    <annot>The score is available on IMSLP: https://imslp.org/wiki/Clavierst%C3%BCck_f%C3%BCr_die_rechte_oder_linke_Hand_allein%2C_H.241_(Bach%2C_Carl_Philipp_Emanuel)</annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/piano/1_hand/Bach_CarlPhilippEmanuel_ClavierstueckFuerDieRechteOderLinkeHandAllein.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/1_hand/Bach_CarlPhilippEmanuel_ClavierstueckFuerDieRechteOderLinkeHandAllein.xml
@@ -5,7 +5,7 @@
     <head>Bach, Carl Philipp Emanuel: Clavierstück für die rechte oder linke Hand allein.</head>
     
     <perfResList>
-        <perfRes auth="ka" label="piano">
+        <perfRes label="piano" codedval="ka">
             <!-- alternatives! -->
             <perfRes label="hand" solo="true" type="alt">right</perfRes>
             <perfRes label="hand" solo="true" type="alt">left</perfRes>

--- a/MEI_4.0/Header/PerfMedium/piano/1_hand/leftHandOnly/Czerny_Carl_DieSchuleDerLinkenHand_Op_399.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/1_hand/leftHandOnly/Czerny_Carl_DieSchuleDerLinkenHand_Op_399.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+    <head>Czerny, Carl: Die Schule der linken Hand, Op.399</head>
+    
+    <perfResList>
+        <perfRes auth="ka" label="piano">
+            <perfRes label="hand">left</perfRes>
+        </perfRes>
+    </perfResList>
+    
+    <annot>@auth.uri for the following &lt;perfRes/&gt; is https://www.loc.gov/standards/valuelist/marcmusperf.html</annot>
+    <annot>The score is available on IMSLP: https://imslp.org/wiki/Die_Schule_der_linken_Hand%2C_Op.399_(Czerny%2C_Carl)</annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/piano/1_hand/leftHandOnly/Czerny_Carl_DieSchuleDerLinkenHand_Op_399.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/1_hand/leftHandOnly/Czerny_Carl_DieSchuleDerLinkenHand_Op_399.xml
@@ -5,7 +5,7 @@
     <head>Czerny, Carl: Die Schule der linken Hand, Op.399</head>
     
     <perfResList>
-        <perfRes auth="ka" label="piano">
+        <perfRes label="piano" codedval="ka">
             <perfRes label="hand">left</perfRes>
         </perfRes>
     </perfResList>

--- a/MEI_4.0/Header/PerfMedium/piano/1_hand/leftHandOnly/Reger_Max_4Spezialstudien_WoO_III_13.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/1_hand/leftHandOnly/Reger_Max_4Spezialstudien_WoO_III_13.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+    <head>Reger, Max: 4 Spezialstudien, WoO III/13</head>
+    
+    <perfResList>
+        <perfRes auth="ka" label="piano">
+            <perfRes label="hand" solo="true">left</perfRes>
+        </perfRes>
+    </perfResList>
+    
+    <annot>@auth.uri for the following &lt;perfRes/&gt; is https://www.loc.gov/standards/valuelist/marcmusperf.html</annot>
+    <annot>The score is available on IMSLP: https://imslp.org/wiki/4_Spezialstudien%2C_WoO_III%2F13_(Reger%2C_Max)</annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/piano/1_hand/leftHandOnly/Reger_Max_4Spezialstudien_WoO_III_13.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/1_hand/leftHandOnly/Reger_Max_4Spezialstudien_WoO_III_13.xml
@@ -5,7 +5,7 @@
     <head>Reger, Max: 4 Spezialstudien, WoO III/13</head>
     
     <perfResList>
-        <perfRes auth="ka" label="piano">
+        <perfRes label="piano" codedval="ka">
             <perfRes label="hand" solo="true">left</perfRes>
         </perfRes>
     </perfResList>

--- a/MEI_4.0/Header/PerfMedium/piano/1_hand/leftHandOnly/Saint-Saens_Camille_6EtudesPourLaMainGaucheSeule_Op135.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/1_hand/leftHandOnly/Saint-Saens_Camille_6EtudesPourLaMainGaucheSeule_Op135.xml
@@ -5,7 +5,7 @@
     <head>Saint-Saëns, Camille: 6 Études pour la main gauche seule, Op.135</head>
     
     <perfResList>
-        <perfRes auth="ka" label="piano">
+        <perfRes label="piano" codedval="ka">
             <perfRes label="hand" solo="true">left</perfRes>
         </perfRes>
     </perfResList>

--- a/MEI_4.0/Header/PerfMedium/piano/1_hand/leftHandOnly/Saint-Saens_Camille_6EtudesPourLaMainGaucheSeule_Op135.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/1_hand/leftHandOnly/Saint-Saens_Camille_6EtudesPourLaMainGaucheSeule_Op135.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+    <head>Saint-Saëns, Camille: 6 Études pour la main gauche seule, Op.135</head>
+    
+    <perfResList>
+        <perfRes auth="ka" label="piano">
+            <perfRes label="hand" solo="true">left</perfRes>
+        </perfRes>
+    </perfResList>
+    
+    <annot>@auth.uri for the following &lt;perfRes/&gt; is https://www.loc.gov/standards/valuelist/marcmusperf.html</annot>
+    <annot>The score is available on IMSLP: https://imslp.org/wiki/6_%C3%89tudes_pour_la_main_gauche_seule%2C_Op.135_(Saint-Sa%C3%ABns%2C_Camille)</annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/piano/1_hand/leftHandOnly/Scriabin_Aleksandr_PreludeAndNocturneForTheLeftHand_Op_9.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/1_hand/leftHandOnly/Scriabin_Aleksandr_PreludeAndNocturneForTheLeftHand_Op_9.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+    <head>Scriabin, Aleksandr: Prelude and Nocturne for the Left Hand, Op.9</head>
+    
+    <perfResList>
+        <perfRes auth="ka" label="piano">
+            <perfRes label="hand" solo="true">left</perfRes>
+        </perfRes>
+    </perfResList>
+    
+    <annot>@auth.uri for the following &lt;perfRes/&gt; is https://www.loc.gov/standards/valuelist/marcmusperf.html</annot>
+    <annot>The score is available on IMSLP: https://imslp.org/wiki/Prelude_and_Nocturne_for_the_Left_Hand%2C_Op.9_(Scriabin%2C_Aleksandr)</annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/piano/1_hand/leftHandOnly/Scriabin_Aleksandr_PreludeAndNocturneForTheLeftHand_Op_9.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/1_hand/leftHandOnly/Scriabin_Aleksandr_PreludeAndNocturneForTheLeftHand_Op_9.xml
@@ -5,7 +5,7 @@
     <head>Scriabin, Aleksandr: Prelude and Nocturne for the Left Hand, Op.9</head>
     
     <perfResList>
-        <perfRes auth="ka" label="piano">
+        <perfRes label="piano" codedval="ka">
             <perfRes label="hand" solo="true">left</perfRes>
         </perfRes>
     </perfResList>

--- a/MEI_4.0/Header/PerfMedium/piano/1_hand/rightHandOnly/Berlioz_Hector_ValseChantee_H131.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/1_hand/rightHandOnly/Berlioz_Hector_ValseChantee_H131.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+    <head>Berlioz, Hector: Valse chantée, H 131</head>
+    
+    <perfResList>
+        <perfRes auth="ka" label="piano">
+            <perfRes label="hand" solo="true">right</perfRes>
+        </perfRes>
+    </perfResList>
+    
+    <annot>@auth.uri for the following &lt;perfRes/&gt; is https://www.loc.gov/standards/valuelist/marcmusperf.html</annot>
+    <annot>The score is available on IMSLP: https://imslp.org/wiki/Valse_chant%C3%A9e%2C_H_131_(Berlioz%2C_Hector)</annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/piano/1_hand/rightHandOnly/Berlioz_Hector_ValseChantee_H131.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/1_hand/rightHandOnly/Berlioz_Hector_ValseChantee_H131.xml
@@ -5,7 +5,7 @@
     <head>Berlioz, Hector: Valse chantée, H 131</head>
     
     <perfResList>
-        <perfRes auth="ka" label="piano">
+        <perfRes label="piano" codedval="ka">
             <perfRes label="hand" solo="true">right</perfRes>
         </perfRes>
     </perfResList>

--- a/MEI_4.0/Header/PerfMedium/piano/2_hands/Haessler_JohannWilhelm_SechsLeichteSonaten_sonata_I-III.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/2_hands/Haessler_JohannWilhelm_SechsLeichteSonaten_sonata_I-III.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+   <head>Sechs leichte Sonaten fürs Clavier oder Piano=Forte, | wovon | Zwei mit Begleitung einer Flöte oder Violine | und | Eine für drei Hände auf Einem Claviere, | von | Johann Wilhelm Häßler, | Musikdirektor des öffentlichen Konzerts und Organist an der Barfüßerkirche in Erfurth.</head>
+   
+   <perfResList label="Sonata I–III">
+      <perfRes auth="ka">piano</perfRes>
+   </perfResList>
+   
+   <annot>@auth.uri for the following &lt;perfRes/&gt; is https://www.loc.gov/standards/valuelist/marcmusperf.html</annot>
+   <annot>The score is available on IMSLP: https://imslp.org/wiki/6_Leichte_Sonaten%2C_Theil_1_(H%C3%A4ssler%2C_Johann_Wilhelm)</annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/piano/2_hands/Haessler_JohannWilhelm_SechsLeichteSonaten_sonata_I-III.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/2_hands/Haessler_JohannWilhelm_SechsLeichteSonaten_sonata_I-III.xml
@@ -5,7 +5,7 @@
    <head>Sechs leichte Sonaten fürs Clavier oder Piano=Forte, | wovon | Zwei mit Begleitung einer Flöte oder Violine | und | Eine für drei Hände auf Einem Claviere, | von | Johann Wilhelm Häßler, | Musikdirektor des öffentlichen Konzerts und Organist an der Barfüßerkirche in Erfurth.</head>
    
    <perfResList label="Sonata I–III">
-      <perfRes auth="ka">piano</perfRes>
+      <perfRes codedval="ka">piano</perfRes>
    </perfResList>
    
    <annot>@auth.uri for the following &lt;perfRes/&gt; is https://www.loc.gov/standards/valuelist/marcmusperf.html</annot>

--- a/MEI_4.0/Header/PerfMedium/piano/2_hands/Kalkbrenner_Friedrich_LesSoupirs_RomanceNo1.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/2_hands/Kalkbrenner_Friedrich_LesSoupirs_RomanceNo1.xml
@@ -5,7 +5,7 @@
    <head>Les Soupirs. | deux Romances | pour le piano | dédicés à son Altesse Royale | Madame la Princesse | Charles de Prusse| par | Fried. Kalkbrenner. | op. 121 [Romance No 1]</head>
    
    <perfResList label="Sonata I–III">
-      <perfRes auth="ka" label="piano">
+      <perfRes label="piano" codedval="ka">
             <!--
                <perfRes label="hand">right</perfRes>
                <perfRes label="hand">left</perfRes>

--- a/MEI_4.0/Header/PerfMedium/piano/2_hands/Kalkbrenner_Friedrich_LesSoupirs_RomanceNo1.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/2_hands/Kalkbrenner_Friedrich_LesSoupirs_RomanceNo1.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+   <head>Les Soupirs. | deux Romances | pour le piano | dédicés à son Altesse Royale | Madame la Princesse | Charles de Prusse| par | Fried. Kalkbrenner. | op. 121 [Romance No 1]</head>
+   
+   <perfResList label="Sonata I–III">
+      <perfRes auth="ka" label="piano">
+            <!--
+               <perfRes label="hand">right</perfRes>
+               <perfRes label="hand">left</perfRes>
+            -->
+      </perfRes>
+   </perfResList>
+   
+   <annot>@auth.uri for the following &lt;perfRes/&gt; is https://www.loc.gov/standards/valuelist/marcmusperf.html</annot>
+   <annot>The score is available on IMSLP: https://imslp.org/wiki/Les_Soupirs%2C_Op.121_(Kalkbrenner%2C_Friedrich_Wilhelm)</annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/piano/3_hands/Haessler_JohannWilhelm_SechsLeichteSonaten_sonata_VI.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/3_hands/Haessler_JohannWilhelm_SechsLeichteSonaten_sonata_VI.xml
@@ -5,7 +5,7 @@
    <head>Sechs leichte Sonaten fürs Clavier oder Piano=Forte, | wovon | Zwei mit Begleitung einer Flöte oder Violine | und | Eine für drei Hände auf Einem Claviere, | von | Johann Wilhelm Häßler, | Musikdirektor des öffentlichen Konzerts und Organist an der Barfüßerkirche in Erfurth.</head>
    
    <perfResList label="Sonata VI">
-      <perfRes auth="ka">piano
+      <perfRes codedval="ka">piano
          <perfRes>hand</perfRes>
          <perfRes>hand</perfRes>
          <perfRes>hand (left)</perfRes>

--- a/MEI_4.0/Header/PerfMedium/piano/3_hands/Haessler_JohannWilhelm_SechsLeichteSonaten_sonata_VI.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/3_hands/Haessler_JohannWilhelm_SechsLeichteSonaten_sonata_VI.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+   <head>Sechs leichte Sonaten fürs Clavier oder Piano=Forte, | wovon | Zwei mit Begleitung einer Flöte oder Violine | und | Eine für drei Hände auf Einem Claviere, | von | Johann Wilhelm Häßler, | Musikdirektor des öffentlichen Konzerts und Organist an der Barfüßerkirche in Erfurth.</head>
+   
+   <perfResList label="Sonata VI">
+      <perfRes auth="ka">piano
+         <perfRes>hand</perfRes>
+         <perfRes>hand</perfRes>
+         <perfRes>hand (left)</perfRes>
+      </perfRes>
+   </perfResList>
+   
+   <annot>@auth.uri for the following &lt;perfRes/&gt; is https://www.loc.gov/standards/valuelist/marcmusperf.html</annot>
+   <annot>The score is available on IMSLP: https://imslp.org/wiki/6_Leichte_Sonaten%2C_Theil_1_(H%C3%A4ssler%2C_Johann_Wilhelm)</annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/piano/3_hands/Holder_JosephWilliam_TrioForPiano3Hands_Op31.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/3_hands/Holder_JosephWilliam_TrioForPiano3Hands_Op31.xml
@@ -6,7 +6,7 @@
    
    <perfResList>
       <!-- piano 3 hands -->
-      <perfRes auth="ka" label="piano">
+      <perfRes label="piano" codedval="ka">
          <perfRes label="primo">
             <!-- alternatives! -->
             <perfRes label="hand" type="alt">right</perfRes>

--- a/MEI_4.0/Header/PerfMedium/piano/3_hands/Holder_JosephWilliam_TrioForPiano3Hands_Op31.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/3_hands/Holder_JosephWilliam_TrioForPiano3Hands_Op31.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+   <head>A | Trio | for | Three Performers | on the | Piano forte, | [...] J. W. Holder, | op. 31</head>
+   
+   <perfResList>
+      <!-- piano 3 hands -->
+      <perfRes auth="ka" label="piano">
+         <perfRes label="primo">
+            <!-- alternatives! -->
+            <perfRes label="hand" type="alt">right</perfRes>
+            <perfRes label="hand" type="alt">left</perfRes>
+         </perfRes>
+         <perfRes label="secondo">
+            <perfRes label="hand">right</perfRes>
+            <perfRes label="hand">left</perfRes>
+         </perfRes>
+      </perfRes>
+   </perfResList>
+   
+   <annot>@auth.uri for the following &lt;perfRes/&gt; is https://www.loc.gov/standards/valuelist/marcmusperf.html</annot>
+   <annot>The score is available on IMSLP: https://imslp.org/wiki/Trio_in_E-flat_major_for_Piano_5-Hands%2C_Op.31_(Holder%2C_Joseph_William)</annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/piano/3_hands/Kalkbrenner_Friedrich_LesSoupirs_RomanceNo2.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/3_hands/Kalkbrenner_Friedrich_LesSoupirs_RomanceNo2.xml
@@ -5,7 +5,7 @@
    <head>Les Soupirs. | deux Romances | pour le piano | dédicés à son Altesse Royale | Madame la Princesse | Charles de Prusse| par | Fried. Kalkbrenner. | op. 121 [Romance No 2]</head>
    
    <perfResList label="Sonata I–III">
-      <perfRes auth="ka" label="piano">
+      <perfRes label="piano" codedval="ka">
          <perfRes label="primo">
             <perfRes label="hand">[right]</perfRes>
          </perfRes>

--- a/MEI_4.0/Header/PerfMedium/piano/3_hands/Kalkbrenner_Friedrich_LesSoupirs_RomanceNo2.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/3_hands/Kalkbrenner_Friedrich_LesSoupirs_RomanceNo2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+   <head>Les Soupirs. | deux Romances | pour le piano | dédicés à son Altesse Royale | Madame la Princesse | Charles de Prusse| par | Fried. Kalkbrenner. | op. 121 [Romance No 2]</head>
+   
+   <perfResList label="Sonata I–III">
+      <perfRes auth="ka" label="piano">
+         <perfRes label="primo">
+            <perfRes label="hand">[right]</perfRes>
+         </perfRes>
+         <perfRes label="secondo">
+            <perfRes label="hand">right</perfRes>
+            <perfRes label="hand">left</perfRes>
+         </perfRes>
+      </perfRes>
+   </perfResList>
+   
+   <annot>@auth.uri for the following &lt;perfRes/&gt; is https://www.loc.gov/standards/valuelist/marcmusperf.html</annot>
+   <annot>The score is available on IMSLP: https://imslp.org/wiki/Les_Soupirs%2C_Op.121_(Kalkbrenner%2C_Friedrich_Wilhelm) page 6</annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/piano/3_hands/Scheidler_JohannDavid_VermischteHandstuecke.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/3_hands/Scheidler_JohannDavid_VermischteHandstuecke.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+   <head>Vermischte Handstücke | für zwo Personen auf einem Clavier | aus dem 18. Jahrhundert | Herausgegeben von | Aldred Kreutz</head>
+   
+   <perfResList>
+      <perfRes auth="ka" label="piano">
+         <perfRes label="primo">
+            <perfRes label="hand">[right]</perfRes>
+         </perfRes>
+         <perfRes label="secondo">
+            <perfRes label="hand">right</perfRes>
+            <perfRes label="hand">left</perfRes>
+         </perfRes>
+      </perfRes>
+   </perfResList>
+   
+   <annot>@auth.uri for the following &lt;perfRes/&gt; is https://www.loc.gov/standards/valuelist/marcmusperf.html</annot>
+   <annot>The score is available on IMSLP: https://imslp.org/wiki/2_Pieces_for_Piano_3-Hands_(Scheidler%2C_Johann_David)</annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/piano/3_hands/Scheidler_JohannDavid_VermischteHandstuecke.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/3_hands/Scheidler_JohannDavid_VermischteHandstuecke.xml
@@ -5,7 +5,7 @@
    <head>Vermischte Handstücke | für zwo Personen auf einem Clavier | aus dem 18. Jahrhundert | Herausgegeben von | Aldred Kreutz</head>
    
    <perfResList>
-      <perfRes auth="ka" label="piano">
+      <perfRes label="piano" codedval="ka">
          <perfRes label="primo">
             <perfRes label="hand">[right]</perfRes>
          </perfRes>

--- a/MEI_4.0/Header/PerfMedium/piano/3_hands/Schwenke_JohannFriedrich_24Nachspiele.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/3_hands/Schwenke_JohannFriedrich_24Nachspiele.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+   <head>Kirchen- und Orgel-Compositionen | von J. F. Schwenke, | Organisten zuu St. Nikolai in Hamburg. | Zweiter Theil. | 24 Nachspiele in allen Tonarten u. 24 Übergänge| für die Orgel mit obligatem Pedal, oder für das Pianoforte (zu 2, 3, oder 4 Händen) | [...]</head>
+   
+   <perfResList type="alternatives">
+      
+      <!-- organ with obbligato pedal -->
+      <perfRes auth="" label="organ">
+         <perfRes label="hand"></perfRes>
+         <perfRes label="hand"></perfRes>
+         <perfRes label="pedal" type="obligat">
+            <!--<perfRes label="foot"/>
+            <perfRes label="foot"/>-->
+         </perfRes>
+      </perfRes>
+      
+      <!-- piano 2 hands -->
+      <perfRes auth="ka" label="piano">
+            <perfRes label="hand">right</perfRes>
+            <perfRes label="hand">left</perfRes>
+      </perfRes>
+      
+      <!-- piano 3 hands -->
+      <perfRes auth="ka" label="piano">
+         <perfRes label="playerOne">
+            <perfRes label="hand">right</perfRes>
+            <perfRes label="hand">left</perfRes>
+         </perfRes>
+         <perfRes label="playerTwo">
+            <perfRes label="hand">[left/right]</perfRes>
+         </perfRes>
+      </perfRes>
+      
+      <!-- piano 4 hands -->
+      <perfRes auth="ka" label="piano">
+         <perfRes label="playerOne">
+            <perfRes label="hand">right</perfRes>
+            <perfRes label="hand">left</perfRes>
+         </perfRes>
+         <perfRes label="playerTwo">
+            <perfRes label="hand">right</perfRes>
+            <perfRes label="hand">left</perfRes>
+         </perfRes>
+      </perfRes>
+   </perfResList>
+   
+   <annot>@auth.uri for the following &lt;perfRes/&gt; is https://www.loc.gov/standards/valuelist/marcmusperf.html</annot>
+   <annot>The score is available on IMSLP: https://imslp.org/wiki/24_Nachspiele_und_24_%C3%9Cberg%C3%A4nge_(Schwencke%2C_Johann_Friedrich)</annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/piano/3_hands/Schwenke_JohannFriedrich_24Nachspiele.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/3_hands/Schwenke_JohannFriedrich_24Nachspiele.xml
@@ -7,7 +7,7 @@
    <perfResList type="alternatives">
       
       <!-- organ with obbligato pedal -->
-      <perfRes auth="" label="organ">
+      <perfRes label="organ" codedval="kb">
          <perfRes label="hand"></perfRes>
          <perfRes label="hand"></perfRes>
          <perfRes label="pedal" type="obligat">
@@ -17,13 +17,13 @@
       </perfRes>
       
       <!-- piano 2 hands -->
-      <perfRes auth="ka" label="piano">
+      <perfRes label="piano" codedval="ka">
             <perfRes label="hand">right</perfRes>
             <perfRes label="hand">left</perfRes>
       </perfRes>
       
       <!-- piano 3 hands -->
-      <perfRes auth="ka" label="piano">
+      <perfRes label="piano" codedval="ka">
          <perfRes label="playerOne">
             <perfRes label="hand">right</perfRes>
             <perfRes label="hand">left</perfRes>
@@ -34,7 +34,7 @@
       </perfRes>
       
       <!-- piano 4 hands -->
-      <perfRes auth="ka" label="piano">
+      <perfRes label="piano" codedval="ka">
          <perfRes label="playerOne">
             <perfRes label="hand">right</perfRes>
             <perfRes label="hand">left</perfRes>

--- a/MEI_4.0/Header/PerfMedium/piano/4_hands/Balakirev_Mily_OnTheVolga.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/4_hands/Balakirev_Mily_OnTheVolga.xml
@@ -6,7 +6,7 @@
    
    <perfResList>
       <!-- piano 4 hands -->
-      <perfRes auth="ka" label="piano">
+      <perfRes label="piano" codedval="ka">
          <perfRes label="primo">
             <perfRes label="hand">right</perfRes>
             <perfRes label="hand">left</perfRes>

--- a/MEI_4.0/Header/PerfMedium/piano/4_hands/Balakirev_Mily_OnTheVolga.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/4_hands/Balakirev_Mily_OnTheVolga.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+   <head>Balakirev, Mily: On the Volga</head>
+   
+   <perfResList>
+      <!-- piano 4 hands -->
+      <perfRes auth="ka" label="piano">
+         <perfRes label="primo">
+            <perfRes label="hand">right</perfRes>
+            <perfRes label="hand">left</perfRes>
+         </perfRes>
+         <perfRes label="secondo">
+            <perfRes label="hand">right</perfRes>
+            <perfRes label="hand">left</perfRes>
+         </perfRes>
+      </perfRes>
+   </perfResList>
+   
+   <annot>@auth.uri for the following &lt;perfRes/&gt; is https://www.loc.gov/standards/valuelist/marcmusperf.html</annot>
+   <annot>The score is available on IMSLP: https://imslp.org/wiki/On_the_Volga_(Balakirev,_Mily)</annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/piano/4_hands/Busoni_Ferruccio_FinnlaendischeVolksweisen_Op27_BV227.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/4_hands/Busoni_Ferruccio_FinnlaendischeVolksweisen_Op27_BV227.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+   <head>Busoni, Ferruccio: Finnländische Volksweisen, Op.27, BV 227</head>
+   
+   <perfResList>
+      <!-- piano 4 hands -->
+      <perfRes auth="ka" label="piano">
+         <perfRes label="playerOne">
+            <perfRes label="hand">right</perfRes>
+            <perfRes label="hand">left</perfRes>
+         </perfRes>
+         <perfRes label="playerTwo">
+            <perfRes label="hand">right</perfRes>
+            <perfRes label="hand">left</perfRes>
+         </perfRes>
+      </perfRes>
+   </perfResList>
+   
+   <annot>@auth.uri for the following &lt;perfRes/&gt; is https://www.loc.gov/standards/valuelist/marcmusperf.html</annot>
+   <annot>The score is available on IMSLP: https://imslp.org/wiki/Finnl%C3%A4ndische_Volksweisen,_Op.27,_BV_227_(Busoni,_Ferruccio)</annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/piano/4_hands/Busoni_Ferruccio_FinnlaendischeVolksweisen_Op27_BV227.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/4_hands/Busoni_Ferruccio_FinnlaendischeVolksweisen_Op27_BV227.xml
@@ -6,7 +6,7 @@
    
    <perfResList>
       <!-- piano 4 hands -->
-      <perfRes auth="ka" label="piano">
+      <perfRes label="piano" codedval="ka">
          <perfRes label="playerOne">
             <perfRes label="hand">right</perfRes>
             <perfRes label="hand">left</perfRes>

--- a/MEI_4.0/Header/PerfMedium/piano/4_hands/Faure_Gabriel_DollySuite_Op56.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/4_hands/Faure_Gabriel_DollySuite_Op56.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+   <head>Dolly | six pièces | pour | piano à 4 mains | par | Gabriel Fauré | op. 56.</head>
+   
+   <perfResList>
+      <!-- piano 4 hands -->
+      <perfRes auth="ka" label="piano">
+         <perfRes label="prima">
+            <perfRes label="hand">right</perfRes>
+            <perfRes label="hand">left</perfRes>
+         </perfRes>
+         <perfRes label="seconda">
+            <perfRes label="hand">right</perfRes>
+            <perfRes label="hand">left</perfRes>
+         </perfRes>
+      </perfRes>
+   </perfResList>
+   
+   <annot>@auth.uri for the following &lt;perfRes/&gt; is https://www.loc.gov/standards/valuelist/marcmusperf.html</annot>
+   <annot>The score is available on IMSLP: https://imslp.org/wiki/Dolly_Suite,_Op.56_(Faur%C3%A9,_Gabriel)</annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/piano/4_hands/Faure_Gabriel_DollySuite_Op56.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/4_hands/Faure_Gabriel_DollySuite_Op56.xml
@@ -6,7 +6,7 @@
    
    <perfResList>
       <!-- piano 4 hands -->
-      <perfRes auth="ka" label="piano">
+      <perfRes label="piano" codedval="ka">
          <perfRes label="prima">
             <perfRes label="hand">right</perfRes>
             <perfRes label="hand">left</perfRes>

--- a/MEI_4.0/Header/PerfMedium/piano/4_hands/Jaell_Marie_12ValsesAndFinale_op8.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/4_hands/Jaell_Marie_12ValsesAndFinale_op8.xml
@@ -6,7 +6,7 @@
    
    <perfResList>
       <!-- piano 4 hands -->
-      <perfRes auth="ka" label="piano">
+      <perfRes label="piano" codedval="ka">
          <perfRes label="prima">
             <perfRes label="hand">right</perfRes>
             <perfRes label="hand">left</perfRes>

--- a/MEI_4.0/Header/PerfMedium/piano/4_hands/Jaell_Marie_12ValsesAndFinale_op8.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/4_hands/Jaell_Marie_12ValsesAndFinale_op8.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+   <head>Jaëll, Marie: 12 Valses and Finale, Op.8</head>
+   
+   <perfResList>
+      <!-- piano 4 hands -->
+      <perfRes auth="ka" label="piano">
+         <perfRes label="prima">
+            <perfRes label="hand">right</perfRes>
+            <perfRes label="hand">left</perfRes>
+         </perfRes>
+         <perfRes label="seconda">
+            <perfRes label="hand">right</perfRes>
+            <perfRes label="hand">left</perfRes>
+         </perfRes>
+      </perfRes>
+   </perfResList>
+   
+   <annot>@auth.uri for the following &lt;perfRes/&gt; is https://www.loc.gov/standards/valuelist/marcmusperf.html</annot>
+   <annot>The score is available on IMSLP: https://imslp.org/wiki/12_Valses_and_Finale,_Op.8_(Ja%C3%ABll,_Marie)</annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/piano/4_hands/Satie_Erik_LaBelleExcentrique.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/4_hands/Satie_Erik_LaBelleExcentrique.xml
@@ -6,7 +6,7 @@
    
    <perfResList>
       <!-- piano 4 hands -->
-      <perfRes auth="ka" label="piano">
+      <perfRes label="piano" codedval="ka">
          <perfRes label="primo">
             <perfRes label="hand">right</perfRes>
             <perfRes label="hand">left</perfRes>

--- a/MEI_4.0/Header/PerfMedium/piano/4_hands/Satie_Erik_LaBelleExcentrique.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/4_hands/Satie_Erik_LaBelleExcentrique.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+   <head>Satie, Erik: La belle excentrique</head>
+   
+   <perfResList>
+      <!-- piano 4 hands -->
+      <perfRes auth="ka" label="piano">
+         <perfRes label="primo">
+            <perfRes label="hand">right</perfRes>
+            <perfRes label="hand">left</perfRes>
+         </perfRes>
+         <perfRes label="secondo">
+            <perfRes label="hand">right</perfRes>
+            <perfRes label="hand">left</perfRes>
+         </perfRes>
+      </perfRes>
+   </perfResList>
+   
+   <annot>@auth.uri for the following &lt;perfRes/&gt; is https://www.loc.gov/standards/valuelist/marcmusperf.html</annot>
+   <annot>The score is available on IMSLP: https://imslp.org/wiki/La_Belle_Excentrique_(Satie,_Erik)</annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/piano/5_hands/Dalberg_JohannFriedrichHugoVon_SonataForPiano5Hands_Op19.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/5_hands/Dalberg_JohannFriedrichHugoVon_SonataForPiano5Hands_Op19.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+   <head>Sonata | à | Cinque Mani | per il | Piano-forte. | Composta da | F. de Dalberg. | op. 19.</head>
+   
+   <perfResList>
+      <!-- piano 5 hands on 1 piano -->
+      <perfRes auth="ka" label="piano">
+         <perfRes label="player.i">
+            <perfRes label="hand">right</perfRes>
+            <perfRes label="hand">left</perfRes>
+         </perfRes>
+         <perfRes label="player.ii">
+            <perfRes label="hand">right</perfRes>
+            <perfRes label="hand">left</perfRes>
+         </perfRes>
+         <perfRes label="player.iii">
+            <perfRes label="hand">la man dritta</perfRes>
+         </perfRes>
+      </perfRes>
+   </perfResList>
+   
+   <annot>@auth.uri for the following &lt;perfRes/&gt; is https://www.loc.gov/standards/valuelist/marcmusperf.html</annot>
+   <annot>The score is available on IMSLP: https://imslp.org/wiki/Sonata_for_Piano_5-Hands%2C_Op.19_(Dalberg%2C_Johann_Friedrich_Hugo_von)</annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/piano/5_hands/Dalberg_JohannFriedrichHugoVon_SonataForPiano5Hands_Op19.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/5_hands/Dalberg_JohannFriedrichHugoVon_SonataForPiano5Hands_Op19.xml
@@ -6,7 +6,7 @@
    
    <perfResList>
       <!-- piano 5 hands on 1 piano -->
-      <perfRes auth="ka" label="piano">
+      <perfRes label="piano" codedval="ka">
          <perfRes label="player.i">
             <perfRes label="hand">right</perfRes>
             <perfRes label="hand">left</perfRes>

--- a/MEI_4.0/Header/PerfMedium/piano/6_hands/Czerny_Carl_FantasieSueLaSonnambula.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/6_hands/Czerny_Carl_FantasieSueLaSonnambula.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+   <head>OEuvre Posthume | La | sonnambula | Fantasie brilliante | pur | le piano | a six mains | par | Ch. Czerny</head>
+   
+   <perfResList>
+      <!-- piano 5 hands on 1 piano -->
+      <perfRes auth="ka" label="piano">
+         <perfRes label="3mePartie">
+            <perfRes label="hand">right</perfRes>
+            <perfRes label="hand">left</perfRes>
+         </perfRes>
+         <perfRes label="2ePartie">
+            <perfRes label="hand">right</perfRes>
+            <perfRes label="hand">left</perfRes>
+         </perfRes>
+         <perfRes label="1rePartie">
+            <perfRes label="hand">right</perfRes>
+            <perfRes label="hand">left</perfRes>
+         </perfRes>
+      </perfRes>
+   </perfResList>
+   
+   <annot>@auth.uri for the following &lt;perfRes/&gt; is https://www.loc.gov/standards/valuelist/marcmusperf.html</annot>
+   <annot>The score is available on IMSLP: https://imslp.org/wiki/Fantaisie_sur_'La_sonnambula'_(Czerny%2C_Carl)</annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/piano/6_hands/Czerny_Carl_FantasieSueLaSonnambula.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/6_hands/Czerny_Carl_FantasieSueLaSonnambula.xml
@@ -6,7 +6,7 @@
    
    <perfResList>
       <!-- piano 5 hands on 1 piano -->
-      <perfRes auth="ka" label="piano">
+      <perfRes label="piano" codedval="ka">
          <perfRes label="3mePartie">
             <perfRes label="hand">right</perfRes>
             <perfRes label="hand">left</perfRes>

--- a/MEI_4.0/Header/PerfMedium/piano/6_hands/Rachmaninoff_Sergei_2PiecesFor6Hands.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/6_hands/Rachmaninoff_Sergei_2PiecesFor6Hands.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+   <head>Rachmaninoff, Sergei: 2 Pieces for 6 Hands</head>
+   
+   <perfResList>
+      <!-- piano 5 hands on 1 piano -->
+      <perfRes auth="ka" label="piano">
+         <perfRes label="part.i">
+            <perfRes label="hand">right</perfRes>
+            <perfRes label="hand">left</perfRes>
+         </perfRes>
+         <perfRes label="part.ii">
+            <perfRes label="hand">right</perfRes>
+            <perfRes label="hand">left</perfRes>
+         </perfRes>
+         <perfRes label="part.iii">
+            <perfRes label="hand">right</perfRes>
+            <perfRes label="hand">left</perfRes>
+         </perfRes>
+      </perfRes>
+   </perfResList>
+   
+   <annot>@auth.uri for the following &lt;perfRes/&gt; is https://www.loc.gov/standards/valuelist/marcmusperf.html</annot>
+   <annot>The score is available on IMSLP: https://imslp.org/wiki/2_Pieces_for_6_Hands_(Rachmaninoff%2C_Sergei)</annot>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/piano/6_hands/Rachmaninoff_Sergei_2PiecesFor6Hands.xml
+++ b/MEI_4.0/Header/PerfMedium/piano/6_hands/Rachmaninoff_Sergei_2PiecesFor6Hands.xml
@@ -6,7 +6,7 @@
    
    <perfResList>
       <!-- piano 5 hands on 1 piano -->
-      <perfRes auth="ka" label="piano">
+      <perfRes label="piano" codedval="ka">
          <perfRes label="part.i">
             <perfRes label="hand">right</perfRes>
             <perfRes label="hand">left</perfRes>

--- a/MEI_4.0/Header/PerfMedium/vocals/choirMixed_group.xml
+++ b/MEI_4.0/Header/PerfMedium/vocals/choirMixed_group.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+    <perfResList>
+        <!-- choir as group (perfResList) -->
+        <perfResList label="choir">
+            <perfRes auth="va">soprano</perfRes>
+            <perfRes auth="vc">alto</perfRes>
+            <perfRes auth="vd">tenor</perfRes>
+            <perfRes auth="vf">bass</perfRes>
+        </perfResList>
+    </perfResList>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/vocals/choirMixed_group.xml
+++ b/MEI_4.0/Header/PerfMedium/vocals/choirMixed_group.xml
@@ -5,10 +5,10 @@
     <perfResList>
         <!-- choir as group (perfResList) -->
         <perfResList label="choir">
-            <perfRes auth="va">soprano</perfRes>
-            <perfRes auth="vc">alto</perfRes>
-            <perfRes auth="vd">tenor</perfRes>
-            <perfRes auth="vf">bass</perfRes>
+            <perfRes codedval="va">soprano</perfRes>
+            <perfRes codedval="vc">alto</perfRes>
+            <perfRes codedval="vd">tenor</perfRes>
+            <perfRes codedval="vf">bass</perfRes>
         </perfResList>
     </perfResList>
 </perfMedium>

--- a/MEI_4.0/Header/PerfMedium/vocals/choirMixed_instrument.xml
+++ b/MEI_4.0/Header/PerfMedium/vocals/choirMixed_instrument.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<perfMedium xmlns="http://www.music-encoding.org/ns/mei">
+    <perfResList>
+        <!-- choir as »instrument« (perfRes) -->
+        <perfRes auth="choir">
+            <perfRes auth="va">soprano</perfRes>
+            <perfRes auth="vc">alto</perfRes>
+            <perfRes auth="vd">tenor</perfRes>
+            <perfRes auth="vf">bass</perfRes>
+        </perfRes>
+    </perfResList>
+</perfMedium>

--- a/MEI_4.0/Header/PerfMedium/vocals/choirMixed_instrument.xml
+++ b/MEI_4.0/Header/PerfMedium/vocals/choirMixed_instrument.xml
@@ -4,11 +4,11 @@
 <perfMedium xmlns="http://www.music-encoding.org/ns/mei">
     <perfResList>
         <!-- choir as »instrument« (perfRes) -->
-        <perfRes auth="choir">
-            <perfRes auth="va">soprano</perfRes>
-            <perfRes auth="vc">alto</perfRes>
-            <perfRes auth="vd">tenor</perfRes>
-            <perfRes auth="vf">bass</perfRes>
+        <perfRes codedval="choir">
+            <perfRes codedval="va">soprano</perfRes>
+            <perfRes codedval="vc">alto</perfRes>
+            <perfRes codedval="vd">tenor</perfRes>
+            <perfRes codedval="vf">bass</perfRes>
         </perfRes>
     </perfResList>
 </perfMedium>

--- a/MEI_4.0/Header/Watermark/watermark_ex_01_simple.xml
+++ b/MEI_4.0/Header/Watermark/watermark_ex_01_simple.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<watermark xmlns="http://www.music-encoding.org/ns/mei">
+    <title>Welhartiz</title>
+    <date label="usage" startdate="1815" enddate="1816">1815–1816</date>
+    <annot>shield with bend, above lily, below additional motif: “JAA”, countermark lettering: „WELHARTIZ”.</annot>
+    <locus>upper right corner [position on the page, where you found the watermark]</locus>
+</watermark>

--- a/MEI_4.0/Header/Watermark/watermark_ex_02_countermarks_and_fig.xml
+++ b/MEI_4.0/Header/Watermark/watermark_ex_02_countermarks_and_fig.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<watermark xmlns="http://www.music-encoding.org/ns/mei">
+    <title>Welhartiz</title>
+    <date label="usage" startdate="1815" enddate="1816">1815–1816</date>
+    <fig>
+        <figDesc>
+            <heraldry type="main" xml:id="watermark_01-1">
+                <annot>shield with bend, above lily, below additional motif: “JAA”</annot>
+                <locus>left</locus>
+                <relationList>
+                    <relation rel="isMainWatermarkOf" target="#watermark_01-2"/>
+                    <relation rel="hasCountermark" target="#watermark_01-2"/>
+                </relationList>
+            </heraldry>
+            <heraldry type="countermark" xml:id="watermark_01-2">
+                <annot>lettering: „WELHARTIZ”.</annot>
+                <locus>right</locus>
+                <relationList>
+                    <relation rel="hasMainWatermark" target="#watermark_01-1"/>
+                    <relation rel="isCountermarkOf" target="#watermark_01-1"/>
+                </relationList>
+            </heraldry>
+        </figDesc>
+    </fig>
+</watermark>

--- a/MEI_4.0/Header/Watermark/watermark_ex_03_connecting_to_WZIS_and_using_terms.xml
+++ b/MEI_4.0/Header/Watermark/watermark_ex_03_connecting_to_WZIS_and_using_terms.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<watermark xmlns="http://www.music-encoding.org/ns/mei">
+    <title>Welhartiz</title>
+    <date label="usage" startdate="1815" enddate="1816">1815–1816</date>
+    <fig>
+        <figDesc>
+            <heraldry type="main" xml:id="watermark_ID_01-01">
+                <identifier type="WZIS" codedval="004001003002011003001"
+                    auth.uri="https://www.wasserzeichen-online.de/wzis/struktur.php?klassi="/>
+                <term>leaf/blossom/tree</term>
+                <term>lily (s. also shield)</term>
+                <term>detached, with additional motif</term>
+                <term>shield</term>
+                <term>letters</term>
+                <term label="initial">IAA</term>
+                <term label="Incomplete">shield content: bend</term>
+                <locus>left</locus>
+                <annot/>
+                <relation rel="hasCountermark" target="#watermark_ID_01-02"/>
+            </heraldry>
+            <heraldry type="countermark" xml:id="watermark_ID_01-02">
+                <identifier type="WZIS" codedval="011004006007"
+                    auth.uri="https://www.wasserzeichen-online.de/wzis/struktur.php?klassi="/>
+                <term>letters/digits</term>
+                <term>more than three letters (words/names)</term>
+                <term>which first letter W</term>
+                <term label="lettering; incomplete">WELHARTIZ</term>
+                <locus>right</locus>
+                <relation rel="isCountermarkOf" target="#watermark_ID_01-01"/>
+            </heraldry>
+        </figDesc>
+    </fig>
+</watermark>

--- a/MEI_4.0/Header/Watermark/watermark_ex_04_with_papermill_metadata.xml
+++ b/MEI_4.0/Header/Watermark/watermark_ex_04_with_papermill_metadata.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<watermark xmlns="http://www.music-encoding.org/ns/mei">
+    <title>Welhartiz</title>
+    <date label="usage" startdate="1815" enddate="1816">1815–1816</date>
+    <fig>
+        <figDesc>
+            <heraldry type="main" xml:id="watermark_ID_01-01">
+                <identifier type="WZIS" codedval="004001003002011003001"
+                    auth.uri="https://www.wasserzeichen-online.de/wzis/struktur.php?klassi="/>
+                <term>leaf/blossom/tree</term>
+                <term>lily (s. also shield)</term>
+                <term>detached, with additional motif</term>
+                <term>shield</term>
+                <term>letters</term>
+                <term label="initial">IAA</term>
+                <term label="Incomplete">shield content: bend</term>
+                <locus>left</locus>
+                <annot/>
+                <relation rel="hasCountermark" target="#watermark_ID_01-02"/>
+            </heraldry>
+            <heraldry type="countermark" xml:id="watermark_ID_01-02">
+                <identifier type="WZIS" codedval="011004006007"
+                    auth.uri="https://www.wasserzeichen-online.de/wzis/struktur.php?klassi="/>
+                <term>letters/digits</term>
+                <term>more than three letters (words/names)</term>
+                <term>which first letter W</term>
+                <term label="lettering; incomplete">WELHARTIZ</term>
+                <locus>right</locus>
+                <relation rel="isCountermarkOf" target="#watermark_ID_01-01"/>
+            </heraldry>
+        </figDesc>
+    </fig>
+    <!-- papermill description (begin) -->
+        <corpName label="papermill">papermill Welhartitz</corpName>
+        <corpName label="company">Georg Appeltauer</corpName>
+        <geogName>
+            <country>czech republic</country>
+            <region>Plzeňský kraj</region>
+            <region>Klatovy</region>
+            <settlement>Velhartice</settlement>
+        </geogName>
+        <annot label="comment">
+            <p>The paper mill was owned by Georg Appeltauer until 1821 and then passed to Joseph Appeltauer.</p>
+        </annot>
+        <bibl>
+            <title type="abbreviated">Schematismus für das Königreich Böhmen auf das Jahr 1817</title>
+            <biblScope unit="page">S.152</biblScope>
+            <ptr target="http://opacplus.bsb-muenchen.de/title/6752392/ft/bsb10011132?page=1114" label="Online-Ressource"/>
+        </bibl>
+    <!-- papermill description (end) -->
+</watermark>


### PR DESCRIPTION
During the discussion of the `<perfMedium>` proposal at metadata-ig meetings, some sample encodings were captured and are now available here as snippets. These are not abstract contents, but the encoded representation of existing cases from the music literature. These are meant to serve as a pool of ideas and are intended to help other users.